### PR TITLE
Adding ability to get screen location for a LatLng

### DIFF
--- a/library/src/main/assets/google_map.html
+++ b/library/src/main/assets/google_map.html
@@ -25,6 +25,11 @@ function initialize() {
   map = new google.maps.Map(document.getElementById('map-canvas'),
       mapOptions);
 
+  // Access to an overlay allows us to easily find pixel location on the map
+  overlay = new google.maps.OverlayView();
+  overlay.draw = function() {};
+  overlay.setMap(map);
+
   google.maps.event.addListener(map, 'click', mapClick);
   google.maps.event.addListener(map, 'center_changed', mapMove)
 
@@ -178,6 +183,12 @@ function getBounds() {
   ne = bounds.getNorthEast();
   sw = bounds.getSouthWest();
   AirMapView.getBoundsCallback(ne.lat(), ne.lng(), sw.lat(), sw.lng());
+}
+
+function getLatLngScreenLocation(lat, lng) {
+    latLng = new google.maps.LatLng(lat, lng)
+    screenLocation = overlay.getProjection().fromLatLngToContainerPixel(latLng);
+    AirMapView.getLatLngScreenLocationCallback(screenLocation.x, screenLocation.y)
 }
 
 // converts an android int color to a web color :)

--- a/library/src/main/java/com/airbnb/android/airmapview/AirMapInterface.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/AirMapInterface.java
@@ -1,5 +1,6 @@
 package com.airbnb.android.airmapview;
 
+import com.airbnb.android.airmapview.listeners.OnLatLngScreenLocationCallback;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.LatLngBounds;
@@ -81,6 +82,13 @@ public interface AirMapInterface {
    * Returns the map screen bounds to the supplied {@link com.airbnb.android.airmapview.listeners.OnMapBoundsCallback}
    */
   void getMapScreenBounds(OnMapBoundsCallback callback);
+
+  /**
+   * Returns the point coordinates of the LatLng in the container to the supplied
+   * {@link OnLatLngScreenLocationCallback}
+   */
+
+  void getLatLngScreenLocation(LatLng latLng, OnLatLngScreenLocationCallback callback);
 
   /**
    * Sets the given {@link LatLngBounds} on the map with the specified padding

--- a/library/src/main/java/com/airbnb/android/airmapview/AirMapInterface.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/AirMapInterface.java
@@ -88,7 +88,7 @@ public interface AirMapInterface {
    * {@link OnLatLngScreenLocationCallback}
    */
 
-  void getLatLngScreenLocation(LatLng latLng, OnLatLngScreenLocationCallback callback);
+  void getScreenLocation(LatLng latLng, OnLatLngScreenLocationCallback callback);
 
   /**
    * Sets the given {@link LatLngBounds} on the map with the specified padding

--- a/library/src/main/java/com/airbnb/android/airmapview/AirMapView.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/AirMapView.java
@@ -203,7 +203,7 @@ public class AirMapView extends FrameLayout
 
   public void getMapMarkerScreenLocation(LatLng latLng, OnLatLngScreenLocationCallback callback) {
     if (isInitialized()) {
-      mapInterface.getLatLngScreenLocation(latLng, callback);
+      mapInterface.getScreenLocation(latLng, callback);
     }
   }
 

--- a/library/src/main/java/com/airbnb/android/airmapview/AirMapView.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/AirMapView.java
@@ -1,10 +1,5 @@
 package com.airbnb.android.airmapview;
 
-import com.google.android.gms.maps.GoogleMap;
-import com.google.android.gms.maps.model.LatLng;
-import com.google.android.gms.maps.model.LatLngBounds;
-import com.google.android.gms.maps.model.Marker;
-
 import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
@@ -18,11 +13,16 @@ import com.airbnb.android.airmapview.listeners.InfoWindowCreator;
 import com.airbnb.android.airmapview.listeners.OnCameraChangeListener;
 import com.airbnb.android.airmapview.listeners.OnCameraMoveListener;
 import com.airbnb.android.airmapview.listeners.OnInfoWindowClickListener;
+import com.airbnb.android.airmapview.listeners.OnLatLngScreenLocationCallback;
 import com.airbnb.android.airmapview.listeners.OnMapBoundsCallback;
 import com.airbnb.android.airmapview.listeners.OnMapClickListener;
 import com.airbnb.android.airmapview.listeners.OnMapInitializedListener;
 import com.airbnb.android.airmapview.listeners.OnMapLoadedListener;
 import com.airbnb.android.airmapview.listeners.OnMapMarkerClickListener;
+import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.model.LatLng;
+import com.google.android.gms.maps.model.LatLngBounds;
+import com.google.android.gms.maps.model.Marker;
 
 public class AirMapView extends FrameLayout
     implements OnCameraChangeListener, OnMapClickListener,
@@ -198,6 +198,12 @@ public class AirMapView extends FrameLayout
   public void getScreenBounds(OnMapBoundsCallback callback) {
     if (isInitialized()) {
       mapInterface.getMapScreenBounds(callback);
+    }
+  }
+
+  public void getMapMarkerScreenLocation(LatLng latLng, OnLatLngScreenLocationCallback callback) {
+    if (isInitialized()) {
+      mapInterface.getLatLngScreenLocation(latLng, callback);
     }
   }
 

--- a/library/src/main/java/com/airbnb/android/airmapview/NativeGoogleMapFragment.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/NativeGoogleMapFragment.java
@@ -138,8 +138,7 @@ public class NativeGoogleMapFragment extends SupportMapFragment implements AirMa
     callback.onMapBoundsReady(builder.build());
   }
 
-  @Override
-  public void getLatLngScreenLocation(LatLng latLng, OnLatLngScreenLocationCallback callback) {
+  @Override public void getScreenLocation(LatLng latLng, OnLatLngScreenLocationCallback callback) {
     callback.onLatLngScreenLocationReady(googleMap.getProjection().toScreenLocation(latLng));
   }
 

--- a/library/src/main/java/com/airbnb/android/airmapview/NativeGoogleMapFragment.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/NativeGoogleMapFragment.java
@@ -1,5 +1,19 @@
 package com.airbnb.android.airmapview;
 
+import android.graphics.Point;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.airbnb.android.airmapview.listeners.InfoWindowCreator;
+import com.airbnb.android.airmapview.listeners.OnCameraChangeListener;
+import com.airbnb.android.airmapview.listeners.OnLatLngScreenLocationCallback;
+import com.airbnb.android.airmapview.listeners.OnInfoWindowClickListener;
+import com.airbnb.android.airmapview.listeners.OnMapBoundsCallback;
+import com.airbnb.android.airmapview.listeners.OnMapClickListener;
+import com.airbnb.android.airmapview.listeners.OnMapLoadedListener;
+import com.airbnb.android.airmapview.listeners.OnMapMarkerClickListener;
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.OnMapReadyCallback;
@@ -11,20 +25,6 @@ import com.google.android.gms.maps.model.CircleOptions;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.LatLngBounds;
 import com.google.android.gms.maps.model.Marker;
-
-import android.graphics.Point;
-import android.os.Bundle;
-import android.view.LayoutInflater;
-import android.view.View;
-import android.view.ViewGroup;
-
-import com.airbnb.android.airmapview.listeners.InfoWindowCreator;
-import com.airbnb.android.airmapview.listeners.OnCameraChangeListener;
-import com.airbnb.android.airmapview.listeners.OnInfoWindowClickListener;
-import com.airbnb.android.airmapview.listeners.OnMapBoundsCallback;
-import com.airbnb.android.airmapview.listeners.OnMapClickListener;
-import com.airbnb.android.airmapview.listeners.OnMapLoadedListener;
-import com.airbnb.android.airmapview.listeners.OnMapMarkerClickListener;
 
 public class NativeGoogleMapFragment extends SupportMapFragment implements AirMapInterface {
 
@@ -136,6 +136,11 @@ public class NativeGoogleMapFragment extends SupportMapFragment implements AirMa
                                                             - vOffset))); // bottom-right
 
     callback.onMapBoundsReady(builder.build());
+  }
+
+  @Override
+  public void getLatLngScreenLocation(LatLng latLng, OnLatLngScreenLocationCallback callback) {
+    callback.onLatLngScreenLocationReady(googleMap.getProjection().toScreenLocation(latLng));
   }
 
   @Override public void setCenter(LatLngBounds latLngBounds, int boundsPadding) {

--- a/library/src/main/java/com/airbnb/android/airmapview/WebViewMapFragment.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/WebViewMapFragment.java
@@ -111,8 +111,7 @@ public abstract class WebViewMapFragment extends Fragment implements AirMapInter
     drawCircle(latLng, radius, borderColor, CIRCLE_BORDER_WIDTH);
   }
 
-  @Override
-  public void drawCircle(LatLng latLng, int radius, int borderColor, int borderWidth) {
+  @Override public void drawCircle(LatLng latLng, int radius, int borderColor, int borderWidth) {
     drawCircle(latLng, radius, borderColor, borderWidth, CIRCLE_FILL_COLOR);
   }
 
@@ -220,16 +219,14 @@ public abstract class WebViewMapFragment extends Fragment implements AirMapInter
     infoWindowCreator = creator;
   }
 
-  @Override
-  public void getMapScreenBounds(OnMapBoundsCallback callback) {
+  @Override public void getMapScreenBounds(OnMapBoundsCallback callback) {
     onMapBoundsCallback = callback;
     webView.loadUrl("javascript:getBounds();");
   }
 
-  @Override
-  public void getLatLngScreenLocation(LatLng latLng, OnLatLngScreenLocationCallback callback) {
+  @Override public void getScreenLocation(LatLng latLng, OnLatLngScreenLocationCallback callback) {
     onLatLngScreenLocationCallback = callback;
-    webView.loadUrl(String.format("javascript:getLatLngScreenLocation(%1$f, %2$f);",
+    webView.loadUrl(String.format("javascript:getScreenLocation(%1$f, %2$f);",
                                   latLng.latitude, latLng.longitude));
   }
 

--- a/library/src/main/java/com/airbnb/android/airmapview/listeners/OnLatLngScreenLocationCallback.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/listeners/OnLatLngScreenLocationCallback.java
@@ -1,0 +1,7 @@
+package com.airbnb.android.airmapview.listeners;
+
+import android.graphics.Point;
+
+public interface OnLatLngScreenLocationCallback {
+    void onLatLngScreenLocationReady(Point point);
+}

--- a/sample/src/main/java/com/airbnb/airmapview/sample/MainActivity.java
+++ b/sample/src/main/java/com/airbnb/airmapview/sample/MainActivity.java
@@ -1,8 +1,6 @@
 package com.airbnb.airmapview.sample;
 
-import com.google.android.gms.maps.model.LatLng;
-import com.google.android.gms.maps.model.Marker;
-
+import android.graphics.Point;
 import android.os.Bundle;
 import android.support.v7.app.ActionBarActivity;
 import android.view.Menu;
@@ -19,16 +17,19 @@ import com.airbnb.android.airmapview.AirMapViewTypes;
 import com.airbnb.android.airmapview.DefaultAirMapViewBuilder;
 import com.airbnb.android.airmapview.listeners.OnCameraChangeListener;
 import com.airbnb.android.airmapview.listeners.OnCameraMoveListener;
+import com.airbnb.android.airmapview.listeners.OnLatLngScreenLocationCallback;
 import com.airbnb.android.airmapview.listeners.OnInfoWindowClickListener;
 import com.airbnb.android.airmapview.listeners.OnMapClickListener;
 import com.airbnb.android.airmapview.listeners.OnMapInitializedListener;
 import com.airbnb.android.airmapview.listeners.OnMapMarkerClickListener;
+import com.google.android.gms.maps.model.LatLng;
+import com.google.android.gms.maps.model.Marker;
 
 
 public class MainActivity extends ActionBarActivity
     implements OnCameraChangeListener, OnMapInitializedListener,
                OnMapClickListener, OnCameraMoveListener, OnMapMarkerClickListener,
-               OnInfoWindowClickListener {
+               OnInfoWindowClickListener, OnLatLngScreenLocationCallback {
 
   private AirMapView map;
   private DefaultAirMapViewBuilder mapViewBuilder;
@@ -110,6 +111,8 @@ public class MainActivity extends ActionBarActivity
       appendLog(
           "Map onMapClick triggered with lat: " + latLng.latitude + ", lng: "
           + latLng.longitude);
+
+      map.getMapInterface().getLatLngScreenLocation(latLng, this);
     } else {
       appendLog("Map onMapClick triggered with null latLng");
     }
@@ -128,7 +131,8 @@ public class MainActivity extends ActionBarActivity
     appendLog("Map onMapMarkerClick triggered with id " + id);
   }
 
-  @Override public void onMapMarkerClick(Marker marker) {
+  @Override
+  public void onMapMarkerClick(Marker marker) {
     appendLog("Map onMapMarkerClick triggered with marker " + marker.getId());
   }
 
@@ -138,5 +142,10 @@ public class MainActivity extends ActionBarActivity
 
   @Override public void onInfoWindowClick(Marker marker) {
     appendLog("Map onInfoWindowClick triggered with marker " + marker.getId());
+  }
+
+  @Override
+  public void onLatLngScreenLocationReady(Point point) {
+    appendLog("LatLng location on screen (x,y): (" + point.x + "," + point.y + ")");
   }
 }

--- a/sample/src/main/java/com/airbnb/airmapview/sample/MainActivity.java
+++ b/sample/src/main/java/com/airbnb/airmapview/sample/MainActivity.java
@@ -112,7 +112,7 @@ public class MainActivity extends ActionBarActivity
           "Map onMapClick triggered with lat: " + latLng.latitude + ", lng: "
           + latLng.longitude);
 
-      map.getMapInterface().getLatLngScreenLocation(latLng, this);
+      map.getMapInterface().getScreenLocation(latLng, this);
     } else {
       appendLog("Map onMapClick triggered with null latLng");
     }
@@ -131,8 +131,7 @@ public class MainActivity extends ActionBarActivity
     appendLog("Map onMapMarkerClick triggered with id " + id);
   }
 
-  @Override
-  public void onMapMarkerClick(Marker marker) {
+  @Override public void onMapMarkerClick(Marker marker) {
     appendLog("Map onMapMarkerClick triggered with marker " + marker.getId());
   }
 
@@ -144,8 +143,7 @@ public class MainActivity extends ActionBarActivity
     appendLog("Map onInfoWindowClick triggered with marker " + marker.getId());
   }
 
-  @Override
-  public void onLatLngScreenLocationReady(Point point) {
+  @Override public void onLatLngScreenLocationReady(Point point) {
     appendLog("LatLng location on screen (x,y): (" + point.x + "," + point.y + ")");
   }
 }


### PR DESCRIPTION
Introduce a new method on the AirMapInterface `getLatLngScreenLocation` to
retrieve the pixel coordinates on the map over a supplied LatLng. Additionally,
add an `overlay` variable to help compute this screen position. Add an example
usage tied in through the existing map click on `MainActivity`.