### PR TITLE
Avoid extra FrameLayout in AirMapView hierarchy using XML merge

### DIFF
--- a/library/src/main/java/com/airbnb/android/airmapview/AirMapView.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/AirMapView.java
@@ -67,7 +67,7 @@ public class AirMapView extends FrameLayout
     this.mapInterface.setOnMapLoadedListener(this);
 
     fragmentManager.beginTransaction()
-        .replace(R.id.map_frame, (Fragment) this.mapInterface)
+        .replace(getId(), (Fragment) this.mapInterface)
         .commit();
 
     fragmentManager.executePendingTransactions();

--- a/library/src/main/res/layout/map_view.xml
+++ b/library/src/main/res/layout/map_view.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/map_frame"
     android:layout_width="match_parent"
     android:layout_height="match_parent" />


### PR DESCRIPTION
AirMapView extends FrameLayout, and then inflates another FrameLayout, which means there are two FrameLayouts in the hierarchy, one of them unused. This has impact on perf. 

This PR flattens the view hierarchy by removing one of the unused FrameLayout-s. 