### PR TITLE
Fixes google web map info window size

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,8 +17,8 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-VERSION_CODE=8
-VERSION_NAME=1.2.0
+VERSION_CODE=9
+VERSION_NAME=1.3.0-SNAPSHOT
 GROUP=com.airbnb.android
 
 POM_DESCRIPTION=A view abstraction to provide a map user interface with varying underlying map providers.

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -24,7 +24,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:22.2.0'
+    compile 'com.android.support:appcompat-v7:22.2.1'
     compile 'com.google.android.gms:play-services-maps:7.5.0'
 
     testCompile 'junit:junit:4.12'

--- a/library/src/main/java/com/airbnb/android/airmapview/AirMapInterface.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/AirMapInterface.java
@@ -183,7 +183,7 @@ public interface AirMapInterface {
   /**
    * Construct a polyline with the given {@link LatLng} points
    */
-  void addPolyline(AirMapPolyline polyline);
+  <T> void addPolyline(AirMapPolyline<T> polyline);
 
   /**
    * Remove the given {@link Polyline}

--- a/library/src/main/java/com/airbnb/android/airmapview/AirMapMarker.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/AirMapMarker.java
@@ -93,74 +93,74 @@ public class AirMapMarker<T> {
     public Builder() {
     }
 
-    public Builder object(T object) {
+    public Builder<T> object(T object) {
       this.object = object;
       return this;
     }
 
-    public Builder id(long id) {
+    public Builder<T> id(long id) {
       this.id = id;
       return this;
     }
 
-    public Builder position(LatLng position) {
+    public Builder<T> position(LatLng position) {
       this.position = position;
       return this;
     }
 
-    public Builder anchor(float u, float v) {
+    public Builder<T> anchor(float u, float v) {
       this.anchorU = u;
       this.anchorV = v;
       return this;
     }
 
-    public Builder infoWindowAnchor(float u, float v) {
+    public Builder<T> infoWindowAnchor(float u, float v) {
       this.infoWindowAnchorU = u;
       this.infoWindowAnchorV = v;
       return this;
     }
 
-    public Builder title(String title) {
+    public Builder<T> title(String title) {
       this.title = title;
       return this;
     }
 
-    public Builder snippet(String snippet) {
+    public Builder<T> snippet(String snippet) {
       this.snippet = snippet;
       return this;
     }
 
-    public Builder iconId(int iconId) {
+    public Builder<T> iconId(int iconId) {
       this.iconId = iconId;
       return this;
     }
 
-    public Builder bitmap(Bitmap bitmap) {
+    public Builder<T> bitmap(Bitmap bitmap) {
       this.bitmap = bitmap;
       return this;
     }
 
-    public Builder draggable(boolean draggable) {
+    public Builder<T> draggable(boolean draggable) {
       this.draggable = draggable;
       return this;
     }
 
-    public Builder visible(boolean visible) {
+    public Builder<T> visible(boolean visible) {
       this.visible = visible;
       return this;
     }
 
-    public Builder flat(boolean flat) {
+    public Builder<T> flat(boolean flat) {
       this.flat = flat;
       return this;
     }
 
-    public Builder rotation(float rotation) {
+    public Builder<T> rotation(float rotation) {
       this.rotation = rotation;
       return this;
     }
 
-    public Builder alpha(float alpha) {
+    public Builder<T> alpha(float alpha) {
       this.alpha = alpha;
       return this;
     }

--- a/library/src/main/java/com/airbnb/android/airmapview/AirMapMarker.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/AirMapMarker.java
@@ -64,11 +64,11 @@ public class AirMapMarker<T> {
   }
 
   /** Sets a marker associated to this object */
-  public void setMarker(Marker marker) {
+  void setGoogleMarker(Marker marker) {
     this.marker = marker;
   }
 
-  public Marker getMarker() {
+  Marker getMarker() {
     return marker;
   }
 

--- a/library/src/main/java/com/airbnb/android/airmapview/AirMapMarker.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/AirMapMarker.java
@@ -1,137 +1,186 @@
 package com.airbnb.android.airmapview;
 
 import android.graphics.Bitmap;
-import android.text.TextUtils;
 
-import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.model.BitmapDescriptor;
 import com.google.android.gms.maps.model.BitmapDescriptorFactory;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.MarkerOptions;
 
 /**
- * Helper class for keeping record of data needed to display map markers, as well as an object T
- * associated with the marker
+ * Wrapper around {@link MarkerOptions}. Keeps record of data needed to display map markers, as
+ * well as an object T associated with the marker.
  */
 public class AirMapMarker<T> {
 
-  private T object;
-  private long id;
-  private LatLng latLng;
-  private String title;
-  private String snippet;
-  private int iconId;
-  private Bitmap bitmap;
-  private Marker googleMarker;
+  private final T object;
+  private final long id;
+  private final MarkerOptions markerOptions;
+  private Marker marker;
 
-  public AirMapMarker(LatLng latLng, long id) {
-    this(null, latLng, id);
+  private AirMapMarker(T object, long id, LatLng position, String title, String snippet,
+      float anchorU, float anchorV, boolean draggable, boolean visible, boolean flat,
+      float rotation, float infoWindowAnchorU, float infoWindowAnchorV, float alpha,
+      BitmapDescriptor icon) {
+    this.object = object;
+    this.id = id;
+    this.markerOptions = new MarkerOptions()
+        .title(title)
+        .position(position)
+        .icon(icon)
+        .snippet(snippet)
+        .anchor(anchorU, anchorV)
+        .draggable(draggable)
+        .visible(visible)
+        .flat(flat)
+        .rotation(rotation)
+        .infoWindowAnchor(infoWindowAnchorU, infoWindowAnchorV)
+        .alpha(alpha);
   }
 
-  public AirMapMarker(T object, LatLng latLng, long id) {
-    this.object = object;
-    this.latLng = latLng;
-    this.id = id;
+  public T object() {
+    return object;
   }
 
   public long getId() {
     return id;
   }
 
-  public AirMapMarker<T> setId(long id) {
-    this.id = id;
-    return this;
-  }
-
   public LatLng getLatLng() {
-    return latLng;
-  }
-
-  public AirMapMarker<T> setLatLng(LatLng latLng) {
-    this.latLng = latLng;
-    return this;
+    return markerOptions.getPosition();
   }
 
   public String getTitle() {
-    return title;
-  }
-
-  public AirMapMarker<T> setTitle(String title) {
-    this.title = title;
-    return this;
+    return markerOptions.getTitle();
   }
 
   public String getSnippet() {
-    return snippet;
+    return markerOptions.getSnippet();
   }
 
-  public AirMapMarker<T> setSnippet(String snippet) {
-    this.snippet = snippet;
-    return this;
+  public MarkerOptions getMarkerOptions() {
+    return markerOptions;
   }
 
-  public int getIconId() {
-    return iconId;
+  /** Sets a marker associated to this object */
+  public void setMarker(Marker marker) {
+    this.marker = marker;
   }
 
-  public AirMapMarker<T> setIconId(int iconId) {
-    this.iconId = iconId;
-    return this;
+  public Marker getMarker() {
+    return marker;
   }
 
-  public AirMapMarker<T> setIcon(Bitmap bitmap) {
-    this.bitmap = bitmap;
-    return this;
-  }
+  public static class Builder<T> {
+    private T object;
+    private long id;
+    private String title;
+    private String snippet;
+    private int iconId;
+    private Bitmap bitmap;
+    private float anchorU;
+    private float anchorV;
+    private float infoWindowAnchorU;
+    private float infoWindowAnchorV;
+    private boolean draggable;
+    private boolean visible;
+    private boolean flat;
+    private float rotation;
+    private float alpha;
+    private LatLng position;
 
-  public T getObject() {
-    return object;
-  }
-
-  public AirMapMarker<T> setObject(T object) {
-    this.object = object;
-    return this;
-  }
-
-  /**
-   * Add this marker to the given {@link com.google.android.gms.maps.GoogleMap} instance
-   *
-   * @param googleMap the {@link com.google.android.gms.maps.GoogleMap} instance to which the marker
-   *                  will be added
-   */
-  public void addToGoogleMap(GoogleMap googleMap) {
-    MarkerOptions options = new MarkerOptions();
-
-    options.position(latLng);
-
-    if (!TextUtils.isEmpty(title)) {
-      options.title(title);
+    public Builder() {
     }
 
-    if (!TextUtils.isEmpty(snippet)) {
-      options.snippet(snippet);
+    public Builder object(T object) {
+      this.object = object;
+      return this;
     }
 
-    if (bitmap != null) {
-      options.icon(BitmapDescriptorFactory.fromBitmap(bitmap));
-    } else if (iconId > 0) {
-      options.icon(BitmapDescriptorFactory.fromResource(iconId));
+    public Builder id(long id) {
+      this.id = id;
+      return this;
     }
 
-    // add the marker and keep a reference so it can be removed
-    googleMarker = googleMap.addMarker(options);
-  }
-
-  /**
-   * Remove this polyline from a GoogleMap (if it was added).
-   *
-   * @return true if the {@link com.google.android.gms.maps.model.Polyline} was removed
-   */
-  public boolean removeFromGoogleMap() {
-    if (googleMarker != null) {
-      googleMarker.remove();
-      return true;
+    public Builder position(LatLng position) {
+      this.position = position;
+      return this;
     }
-    return false;
+
+    public Builder anchor(float u, float v) {
+      this.anchorU = u;
+      this.anchorV = v;
+      return this;
+    }
+
+    public Builder infoWindowAnchor(float u, float v) {
+      this.infoWindowAnchorU = u;
+      this.infoWindowAnchorV = v;
+      return this;
+    }
+
+    public Builder title(String title) {
+      this.title = title;
+      return this;
+    }
+
+    public Builder snippet(String snippet) {
+      this.snippet = snippet;
+      return this;
+    }
+
+    public Builder iconId(int iconId) {
+      this.iconId = iconId;
+      return this;
+    }
+
+    public Builder bitmap(Bitmap bitmap) {
+      this.bitmap = bitmap;
+      return this;
+    }
+
+    public Builder draggable(boolean draggable) {
+      this.draggable = draggable;
+      return this;
+    }
+
+    public Builder visible(boolean visible) {
+      this.visible = visible;
+      return this;
+    }
+
+    public Builder flat(boolean flat) {
+      this.flat = flat;
+      return this;
+    }
+
+    public Builder rotation(float rotation) {
+      this.rotation = rotation;
+      return this;
+    }
+
+    public Builder alpha(float alpha) {
+      this.alpha = alpha;
+      return this;
+    }
+
+    public AirMapMarker<T> build() {
+      BitmapDescriptor icon;
+      try {
+        if (bitmap != null) {
+          icon = BitmapDescriptorFactory.fromBitmap(bitmap);
+        } else if (iconId > 0) {
+          icon = BitmapDescriptorFactory.fromResource(iconId);
+        } else {
+          icon = null;
+        }
+      } catch (NullPointerException e) {
+        // google play services is not available
+        icon = null;
+      }
+      return new AirMapMarker<>(object, id, position, title, snippet, anchorU, anchorV, draggable,
+          visible, flat, rotation, infoWindowAnchorU, infoWindowAnchorV, alpha, icon);
+    }
   }
 }

--- a/library/src/main/java/com/airbnb/android/airmapview/NativeGoogleMapFragment.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/NativeGoogleMapFragment.java
@@ -77,11 +77,15 @@ public class NativeGoogleMapFragment extends SupportMapFragment implements AirMa
   }
 
   @Override public void addMarker(AirMapMarker airMarker) {
-    airMarker.addToGoogleMap(googleMap);
+    Marker marker = googleMap.addMarker(airMarker.getMarkerOptions());
+    airMarker.setMarker(marker);
   }
 
   @Override public void removeMarker(AirMapMarker marker) {
-    marker.removeFromGoogleMap();
+    Marker nativeMarker = marker.getMarker();
+    if (nativeMarker != null) {
+      nativeMarker.remove();
+    }
   }
 
   @Override public void setOnInfoWindowClickListener(final OnInfoWindowClickListener listener) {

--- a/library/src/main/java/com/airbnb/android/airmapview/NativeGoogleMapFragment.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/NativeGoogleMapFragment.java
@@ -78,7 +78,7 @@ public class NativeGoogleMapFragment extends SupportMapFragment implements AirMa
 
   @Override public void addMarker(AirMapMarker airMarker) {
     Marker marker = googleMap.addMarker(airMarker.getMarkerOptions());
-    airMarker.setMarker(marker);
+    airMarker.setGoogleMarker(marker);
   }
 
   @Override public void removeMarker(AirMapMarker marker) {

--- a/library/src/main/java/com/airbnb/android/airmapview/WebViewMapFragment.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/WebViewMapFragment.java
@@ -356,7 +356,6 @@ public abstract class WebViewMapFragment extends Fragment implements AirMapInter
             infoWindowView.setOnClickListener(new View.OnClickListener() {
               @Override
               public void onClick(@NonNull View v) {
-                mLayout.removeView(infoWindowView);
                 if (onInfoWindowClickListener != null) {
                   onInfoWindowClickListener.onInfoWindowClick(markerId);
                 }

--- a/library/src/main/java/com/airbnb/android/airmapview/WebViewMapFragment.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/WebViewMapFragment.java
@@ -8,7 +8,6 @@ import android.os.Looper;
 import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.util.Log;
-import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -17,7 +16,6 @@ import android.webkit.JavascriptInterface;
 import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
-import android.widget.FrameLayout;
 
 import com.airbnb.android.airmapview.listeners.InfoWindowCreator;
 import com.airbnb.android.airmapview.listeners.OnCameraChangeListener;
@@ -34,8 +32,6 @@ import com.google.android.gms.maps.model.LatLngBounds;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-
-import java.util.List;
 
 public abstract class WebViewMapFragment extends Fragment implements AirMapInterface {
 
@@ -73,7 +69,7 @@ public abstract class WebViewMapFragment extends Fragment implements AirMapInter
     }
   }
 
-  @SuppressLint({"SetJavaScriptEnabled", "AddJavascriptInterface"})
+  @SuppressLint({ "SetJavaScriptEnabled", "AddJavascriptInterface" })
   @Override public View onCreateView(
       LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
     View view = inflater.inflate(R.layout.fragment_webview, container, false);
@@ -91,7 +87,7 @@ public abstract class WebViewMapFragment extends Fragment implements AirMapInter
 
     AirMapType mapType = AirMapType.fromBundle(getArguments());
     webView.loadDataWithBaseURL(mapType.getDomain(), mapType.getMapData(getResources()),
-              "text/html", "base64", null);
+        "text/html", "base64", null);
 
     webView.addJavascriptInterface(new MapsJavaScriptInterface(), "AirMapView");
 
@@ -108,7 +104,7 @@ public abstract class WebViewMapFragment extends Fragment implements AirMapInter
 
   public void setCenter(LatLng latLng) {
     webView.loadUrl(String.format("javascript:centerMap(%1$f, %2$f);", latLng.latitude,
-                                  latLng.longitude));
+        latLng.longitude));
   }
 
   public void animateCenter(LatLng latLng) {
@@ -132,10 +128,10 @@ public abstract class WebViewMapFragment extends Fragment implements AirMapInter
   }
 
   @Override public void drawCircle(LatLng latLng, int radius, int borderColor, int borderWidth,
-                         int fillColor) {
+      int fillColor) {
     webView.loadUrl(String.format("javascript:addCircle(%1$f, %2$f, %3$d, %4$d, %5$d, %6$d);",
-                                  latLng.latitude, latLng.longitude, radius, borderColor,
-                                  borderWidth, fillColor));
+        latLng.latitude, latLng.longitude, radius, borderColor,
+        borderWidth, fillColor));
   }
 
   public void highlightMarker(long markerId) {
@@ -209,14 +205,14 @@ public abstract class WebViewMapFragment extends Fragment implements AirMapInter
     return trackUserLocation;
   }
 
-  @Override public void setMapToolbarEnabled(boolean enabled){
+  @Override public void setMapToolbarEnabled(boolean enabled) {
     // no-op
   }
 
-  @Override public void addPolyline(AirMapPolyline polyline) {
+  @Override public <T> void addPolyline(AirMapPolyline<T> polyline) {
     try {
       JSONArray array = new JSONArray();
-      for (LatLng point : (List<LatLng>) polyline.getPoints()) {
+      for (LatLng point : polyline.getPoints()) {
         JSONObject json = new JSONObject();
         json.put("lat", point.latitude);
         json.put("lng", point.longitude);
@@ -244,7 +240,7 @@ public abstract class WebViewMapFragment extends Fragment implements AirMapInter
   }
 
   @Override public void setInfoWindowCreator(GoogleMap.InfoWindowAdapter adapter,
-                                   InfoWindowCreator creator) {
+      InfoWindowCreator creator) {
     infoWindowCreator = creator;
   }
 
@@ -256,14 +252,14 @@ public abstract class WebViewMapFragment extends Fragment implements AirMapInter
   @Override public void getScreenLocation(LatLng latLng, OnLatLngScreenLocationCallback callback) {
     onLatLngScreenLocationCallback = callback;
     webView.loadUrl(String.format("javascript:getScreenLocation(%1$f, %2$f);",
-                                  latLng.latitude, latLng.longitude));
+        latLng.latitude, latLng.longitude));
   }
 
   @Override public void setCenter(LatLngBounds bounds, int boundsPadding) {
     webView.loadUrl(String.format("javascript:setBounds(%1$f, %2$f, %3$f, %4$f);",
-                                   bounds.northeast.latitude, bounds.northeast.longitude,
-                                   bounds.southwest.latitude,
-                                   bounds.southwest.longitude));
+        bounds.northeast.latitude, bounds.northeast.longitude,
+        bounds.southwest.latitude,
+        bounds.southwest.longitude));
   }
 
   private class MapsJavaScriptInterface {
@@ -299,7 +295,7 @@ public abstract class WebViewMapFragment extends Fragment implements AirMapInter
     @JavascriptInterface public void getBoundsCallback(
         double neLat, double neLng, double swLat, double swLng) {
       final LatLngBounds bounds = new LatLngBounds(new LatLng(swLat, swLng),
-                                                   new LatLng(neLat, neLng));
+          new LatLng(neLat, neLng));
       handler.post(new Runnable() {
         @Override
         public void run() {
@@ -356,13 +352,7 @@ public abstract class WebViewMapFragment extends Fragment implements AirMapInter
           // TODO convert to custom dialog fragment
           if (infoWindowCreator != null) {
             infoWindowView = infoWindowCreator.createInfoWindow(markerId);
-            int height = (int) getResources().getDimension(R.dimen.map_marker_height);
-            FrameLayout.LayoutParams layoutParams = new FrameLayout.LayoutParams(
-                FrameLayout.LayoutParams.WRAP_CONTENT, height, Gravity.CENTER);
-            layoutParams.bottomMargin = height;
-            infoWindowView.setLayoutParams(layoutParams);
             mLayout.addView(infoWindowView);
-
             infoWindowView.setOnClickListener(new View.OnClickListener() {
               @Override
               public void onClick(@NonNull View v) {
@@ -385,7 +375,7 @@ public abstract class WebViewMapFragment extends Fragment implements AirMapInter
       handler.post(new Runnable() {
         @Override
         public void run() {
-          if(onInfoWindowClickListener != null){
+          if (onInfoWindowClickListener != null) {
             onInfoWindowClickListener.onInfoWindowClick(markerId);
           }
         }

--- a/library/src/main/java/com/airbnb/android/airmapview/WebViewMapFragment.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/WebViewMapFragment.java
@@ -352,15 +352,17 @@ public abstract class WebViewMapFragment extends Fragment implements AirMapInter
           // TODO convert to custom dialog fragment
           if (infoWindowCreator != null) {
             infoWindowView = infoWindowCreator.createInfoWindow(markerId);
-            mLayout.addView(infoWindowView);
-            infoWindowView.setOnClickListener(new View.OnClickListener() {
-              @Override
-              public void onClick(@NonNull View v) {
-                if (onInfoWindowClickListener != null) {
-                  onInfoWindowClickListener.onInfoWindowClick(markerId);
+            if (infoWindowView != null) {
+              mLayout.addView(infoWindowView);
+              infoWindowView.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(@NonNull View v) {
+                  if (onInfoWindowClickListener != null) {
+                    onInfoWindowClickListener.onInfoWindowClick(markerId);
+                  }
                 }
-              }
-            });
+              });
+            }
           } else {
             webView.loadUrl(String.format("javascript:showDefaultInfoWindow(%1$d);", markerId));
           }

--- a/library/src/main/java/com/airbnb/android/airmapview/listeners/InfoWindowCreator.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/listeners/InfoWindowCreator.java
@@ -3,6 +3,6 @@ package com.airbnb.android.airmapview.listeners;
 import android.view.View;
 
 public interface InfoWindowCreator {
-
+  // TODO: this should take an AirMapMarker instead of just the ID
   View createInfoWindow(long id);
 }

--- a/library/src/main/res/values/dimens.xml
+++ b/library/src/main/res/values/dimens.xml
@@ -2,5 +2,4 @@
 <resources>
     <dimen name="map_horizontal_padding">20dp</dimen>
     <dimen name="map_vertical_padding">40dp</dimen>
-    <dimen name="map_marker_height">110dp</dimen>
 </resources>

--- a/sample/src/main/java/com/airbnb/airmapview/sample/MainActivity.java
+++ b/sample/src/main/java/com/airbnb/airmapview/sample/MainActivity.java
@@ -34,8 +34,8 @@ import java.util.Arrays;
 
 public class MainActivity extends AppCompatActivity
     implements OnCameraChangeListener, OnMapInitializedListener,
-               OnMapClickListener, OnCameraMoveListener, OnMapMarkerClickListener,
-               OnInfoWindowClickListener, OnLatLngScreenLocationCallback {
+    OnMapClickListener, OnCameraMoveListener, OnMapMarkerClickListener,
+    OnInfoWindowClickListener, OnLatLngScreenLocationCallback {
 
   private AirMapView map;
   private DefaultAirMapViewBuilder mapViewBuilder;
@@ -97,8 +97,8 @@ public class MainActivity extends AppCompatActivity
         airMapInterface = mapViewBuilder.builder(AirMapViewTypes.NATIVE).build();
       } catch (UnsupportedOperationException e) {
         Toast.makeText(this, "Sorry, native Google Maps are not supported by this device. " +
-                             "Please make sure you have Google Play Services installed.",
-                       Toast.LENGTH_SHORT).show();
+                "Please make sure you have Google Play Services installed.",
+            Toast.LENGTH_SHORT).show();
       }
     } else if (id == R.id.action_mapbox_map) {
       airMapInterface = mapViewBuilder.builder(AirMapViewTypes.WEB).build();
@@ -118,7 +118,7 @@ public class MainActivity extends AppCompatActivity
 
   @Override public void onCameraChanged(LatLng latLng, int zoom) {
     appendLog("Map onCameraChanged triggered with lat: " + latLng.latitude + ", lng: "
-              + latLng.longitude);
+        + latLng.longitude);
   }
 
   @Override public void onMapInitialized() {
@@ -132,9 +132,9 @@ public class MainActivity extends AppCompatActivity
 
     // Add Polylines
     LatLng[] latLngs = {
-      new LatLng(37.77977, -122.38937),
-      new LatLng(37.77811, -122.39160),
-      new LatLng(37.77787, -122.38864) };
+        new LatLng(37.77977, -122.38937),
+        new LatLng(37.77811, -122.39160),
+        new LatLng(37.77787, -122.38864) };
 
     map.addPolyline(new AirMapPolyline(Arrays.asList(latLngs), 5));
 
@@ -143,16 +143,19 @@ public class MainActivity extends AppCompatActivity
   }
 
   private void addMarker(String title, LatLng latLng, int id) {
-    map.addMarker(new AirMapMarker(latLng, id)
-            .setTitle(title)
-            .setIconId(R.mipmap.icon_location_pin));
+    map.addMarker(new AirMapMarker.Builder()
+        .id(id)
+        .position(latLng)
+        .title(title)
+        .iconId(R.mipmap.icon_location_pin)
+        .build());
   }
 
   @Override public void onMapClick(LatLng latLng) {
     if (latLng != null) {
       appendLog(
           "Map onMapClick triggered with lat: " + latLng.latitude + ", lng: "
-          + latLng.longitude);
+              + latLng.longitude);
 
       map.getMapInterface().getScreenLocation(latLng, this);
     } else {


### PR DESCRIPTION
We were setting a hardcoded height and margin on the View returned from `InfoWindowCreator.createInfoWindow()`. This removes that and lets the view control its own size.
Also improve the `AirMapMarker` API by making it have the same information as `Marker` plus a bonus builder.

@petzel @nwadams