### PR TITLE
Prevent crash on Android M new permission model

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-22.0.1
-    - android-22
+    - build-tools-23.0.0
+    - android-23
     - extra-google-google_play_services
     - extra-android-m2repository
     - extra-android-support

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:1.3.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 apply from: 'gradle-maven-push.gradle'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.0"
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 22
+        targetSdkVersion 23
     }
 
     compileOptions {
@@ -24,8 +24,8 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:22.2.1'
-    compile 'com.google.android.gms:play-services-maps:7.5.0'
+    compile 'com.android.support:appcompat-v7:23.0.0'
+    compile 'com.google.android.gms:play-services-maps:7.8.0'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'

--- a/library/src/main/java/com/airbnb/android/airmapview/AirMapView.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/AirMapView.java
@@ -78,9 +78,8 @@ public class AirMapView extends FrameLayout
    * @param fragmentManager required for initialization
    */
   public void initialize(FragmentManager fragmentManager) {
-    AirMapInterface
-        mapInterface =
-        (AirMapInterface) fragmentManager.findFragmentById(R.id.map_frame);
+    AirMapInterface mapInterface = (AirMapInterface)
+        fragmentManager.findFragmentById(R.id.map_frame);
 
     if (mapInterface != null) {
       initialize(fragmentManager, mapInterface);

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.0"
 
     defaultConfig {
         applicationId "com.airbnb.airmapview.sample"
         minSdkVersion 14
-        targetSdkVersion 22
+        targetSdkVersion 23
         versionCode 1
         versionName "1.0"
     }
@@ -31,5 +31,5 @@ android {
 dependencies {
     compile project(':library')
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:22.2.0'
+    compile 'com.android.support:appcompat-v7:23.0.0'
 }

--- a/sample/src/main/java/com/airbnb/airmapview/sample/MainActivity.java
+++ b/sample/src/main/java/com/airbnb/airmapview/sample/MainActivity.java
@@ -97,7 +97,8 @@ public class MainActivity extends AppCompatActivity
         airMapInterface = mapViewBuilder.builder(AirMapViewTypes.NATIVE).build();
       } catch (UnsupportedOperationException e) {
         Toast.makeText(this, "Sorry, native Google Maps are not supported by this device. " +
-                "Please make sure you have Google Play Services installed.",
+                "Please make sure you have Google Play Services installed and the permission to " +
+                "write to external storage has been granted.",
             Toast.LENGTH_SHORT).show();
       }
     } else if (id == R.id.action_mapbox_map) {


### PR DESCRIPTION
Native Google Maps needs `WRITE_EXTERNAL_STORAGE` permission on Android M, so we should check for that as well before assuming that it is supported.
This prevents AirMapView from crashing on M.

@petzel @nwadams 