### PR TITLE
Use correct marker URL for Google china map type

### DIFF
--- a/library/src/main/assets/google_map.html
+++ b/library/src/main/assets/google_map.html
@@ -20,11 +20,9 @@ var infoWindowContent = {};
 var polylines = {};
 var moveTimeout;
 var GeoMarker = null;
-var isChinaMode = false;
+var markerIconPrefix;
 
 function initialize() {
-  AirMapView.onJavaScriptInit();
-
   var mapOptions = {
     zoom: 10,
     disableDefaultUI: true,
@@ -47,12 +45,11 @@ function initialize() {
   AirMapView.onMapLoaded();
 }
 
-function setChinaMode() {
-  isChinaMode = true;
-}
-
 function getMarkerIcon(iconFile) {
-    return iconUrl = (isChinaMode ? 'http://ditu.google.cn/mapfiles/ms/icons/' : 'http://maps.google.com/mapfiles/ms/icons/') + iconFile;
+  if (markerIconPrefix === undefined) {
+    markerIconPrefix = AirMapView.isChinaMode() ? 'http://ditu.google.cn/mapfiles/ms/icons/' : 'http://maps.google.com/mapfiles/ms/icons/';
+  }
+  return markerIconPrefix + iconFile;
 }
 
 function startTrackingUserLocation() {

--- a/library/src/main/assets/google_map.html
+++ b/library/src/main/assets/google_map.html
@@ -20,7 +20,11 @@ var infoWindowContent = {};
 var polylines = {};
 var moveTimeout;
 var GeoMarker = null;
+var isChinaMode = false;
+
 function initialize() {
+  AirMapView.onJavaScriptInit();
+
   var mapOptions = {
     zoom: 10,
     disableDefaultUI: true,
@@ -41,6 +45,14 @@ function initialize() {
   google.maps.event.addListener(map, 'center_changed', mapMove)
 
   AirMapView.onMapLoaded();
+}
+
+function setChinaMode() {
+  isChinaMode = true;
+}
+
+function getMarkerIcon(iconFile) {
+    return iconUrl = (isChinaMode ? 'http://ditu.google.cn/mapfiles/ms/icons/' : 'http://maps.google.com/mapfiles/ms/icons/') + iconFile;
 }
 
 function startTrackingUserLocation() {
@@ -77,14 +89,14 @@ function setZoom(zoom) {
 function highlightMarker(markerId) {
   var marker = markers[markerId];
   if (marker != null) {
-    marker.setIcon('http://maps.google.com/mapfiles/ms/icons/purple-dot.png');
+    marker.setIcon(getMarkerIcon('purple-dot.png'));
   }
 }
 
 function unhighlightMarker(markerId) {
   var marker = markers[markerId];
   if (marker != null) {
-    marker.setIcon('http://maps.google.com/mapfiles/ms/icons/red-dot.png');
+    marker.setIcon(getMarkerIcon('red-dot.png'));
   }
 }
 
@@ -93,7 +105,7 @@ function addMarker(lat, lng) {
   var marker = new google.maps.Marker({
       position: position,
       map: map,
-      icon: "http://maps.google.com/mapfiles/ms/icons/green-dot.png"
+      icon: getMarkerIcon('green-dot.png')
   });
 }
 
@@ -102,7 +114,7 @@ function addMarkerWithId(lat, lng, id, title, snippet) {
   var marker = new google.maps.Marker({
       position: position,
       map: map,
-      icon: 'http://maps.google.com/mapfiles/ms/icons/red-dot.png'
+      icon: getMarkerIcon('red-dot.png')
   });
 
   if(title != "null" || snippet != "null") {

--- a/library/src/main/java/com/airbnb/android/airmapview/GoogleChinaWebViewMapFragment.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/GoogleChinaWebViewMapFragment.java
@@ -7,8 +7,7 @@ public class GoogleChinaWebViewMapFragment extends GoogleWebViewMapFragment {
   }
 
   @Override
-  protected void onJavaScriptInit() {
-    super.onJavaScriptInit();
-    webView.loadUrl("javascript:setChinaMode()");
+  protected boolean isChinaMode() {
+    return true;
   }
 }

--- a/library/src/main/java/com/airbnb/android/airmapview/GoogleChinaWebViewMapFragment.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/GoogleChinaWebViewMapFragment.java
@@ -5,4 +5,10 @@ public class GoogleChinaWebViewMapFragment extends GoogleWebViewMapFragment {
     return (GoogleChinaWebViewMapFragment) new GoogleChinaWebViewMapFragment()
         .setArguments(mapType);
   }
+
+  @Override
+  protected void onJavaScriptInit() {
+    super.onJavaScriptInit();
+    webView.loadUrl("javascript:setChinaMode()");
+  }
 }

--- a/library/src/main/java/com/airbnb/android/airmapview/WebViewMapFragment.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/WebViewMapFragment.java
@@ -302,9 +302,22 @@ public abstract class WebViewMapFragment extends Fragment implements AirMapInter
         bounds.southwest.longitude));
   }
 
+  protected void onJavaScriptInit() {
+    // do nothing
+  }
+
   private class MapsJavaScriptInterface {
 
     private final Handler handler = new Handler(Looper.getMainLooper());
+
+    @JavascriptInterface public void onJavaScriptInit() {
+      handler.post(new Runnable() {
+        @Override
+        public void run() {
+          WebViewMapFragment.this.onJavaScriptInit();
+        }
+      });
+    }
 
     @JavascriptInterface public void onMapLoaded() {
       handler.post(new Runnable() {

--- a/library/src/main/java/com/airbnb/android/airmapview/WebViewMapFragment.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/WebViewMapFragment.java
@@ -302,21 +302,16 @@ public abstract class WebViewMapFragment extends Fragment implements AirMapInter
         bounds.southwest.longitude));
   }
 
-  protected void onJavaScriptInit() {
-    // do nothing
+  protected boolean isChinaMode() {
+    return false;
   }
 
   private class MapsJavaScriptInterface {
 
     private final Handler handler = new Handler(Looper.getMainLooper());
 
-    @JavascriptInterface public void onJavaScriptInit() {
-      handler.post(new Runnable() {
-        @Override
-        public void run() {
-          WebViewMapFragment.this.onJavaScriptInit();
-        }
-      });
+    @JavascriptInterface public boolean isChinaMode() {
+      return WebViewMapFragment.this.isChinaMode();
     }
 
     @JavascriptInterface public void onMapLoaded() {

--- a/sample/src/main/java/com/airbnb/airmapview/sample/MainActivity.java
+++ b/sample/src/main/java/com/airbnb/airmapview/sample/MainActivity.java
@@ -19,6 +19,7 @@ import com.airbnb.android.airmapview.AirMapPolyline;
 import com.airbnb.android.airmapview.AirMapView;
 import com.airbnb.android.airmapview.AirMapViewTypes;
 import com.airbnb.android.airmapview.DefaultAirMapViewBuilder;
+import com.airbnb.android.airmapview.GoogleChinaMapType;
 import com.airbnb.android.airmapview.MapType;
 import com.airbnb.android.airmapview.WebAirMapViewBuilder;
 import com.airbnb.android.airmapview.listeners.OnCameraChangeListener;
@@ -93,21 +94,31 @@ public class MainActivity extends AppCompatActivity
 
     AirMapInterface airMapInterface = null;
 
-    if (id == R.id.action_native_map) {
-      try {
-        airMapInterface = mapViewBuilder.builder(AirMapViewTypes.NATIVE).build();
-      } catch (UnsupportedOperationException e) {
-        Toast.makeText(this, "Sorry, native Google Maps are not supported by this device. " +
-                "Please make sure you have Google Play Services installed.",
-            Toast.LENGTH_SHORT).show();
-      }
-    } else if (id == R.id.action_mapbox_map) {
-      airMapInterface = mapViewBuilder.builder(AirMapViewTypes.WEB).build();
-    } else if (id == R.id.action_google_web_map) {
-      // force Google Web maps since otherwise AirMapViewTypes.WEB returns MapBox by default.
-      airMapInterface = new WebAirMapViewBuilder().build();
-    } else if (id == R.id.action_clear_logs) {
-      textLogs.setText("");
+    switch (id) {
+      case R.id.action_native_map:
+        try {
+          airMapInterface = mapViewBuilder.builder(AirMapViewTypes.NATIVE).build();
+        } catch (UnsupportedOperationException e) {
+          Toast.makeText(this, "Sorry, native Google Maps are not supported by this device. " +
+                          "Please make sure you have Google Play Services installed.",
+                  Toast.LENGTH_SHORT).show();
+        }
+        break;
+      case R.id.action_mapbox_map:
+        airMapInterface = mapViewBuilder.builder(AirMapViewTypes.WEB).build();
+        break;
+      case R.id.action_google_web_map:
+        // force Google Web maps since otherwise AirMapViewTypes.WEB returns MapBox by default.
+        airMapInterface = new WebAirMapViewBuilder().build();
+        break;
+      case R.id.action_google_china_web_map:
+        airMapInterface = new WebAirMapViewBuilder().withOptions(new GoogleChinaMapType()).build();
+        break;
+      case R.id.action_clear_logs:
+        textLogs.setText("");
+        break;
+      default:
+        break;
     }
 
     if (airMapInterface != null) {

--- a/sample/src/main/res/menu/menu_main.xml
+++ b/sample/src/main/res/menu/menu_main.xml
@@ -13,6 +13,11 @@
           android:orderInCategory="100"
           app:showAsAction="never"/>
 
+    <item android:id="@+id/action_google_china_web_map"
+        android:title="Use Google China Web Map"
+        android:orderInCategory="100"
+        app:showAsAction="never"/>
+
     <item android:id="@+id/action_mapbox_map"
           android:title="Use MapBox Map"
           android:orderInCategory="100"


### PR DESCRIPTION
Summary:
We're using marker assets from maps.google.com for GoogleChinaMapType,
which will result in markers not shown because it is not accessible.

Adding a fragment sub-class for china map type, and add
a callback onJavaScriptInit so that we can toggle china mode and use the
correct asset URLs later.

Test Plan:
Added a test case for china map.
1) Simulate china network environment.
2) open china map.
3) before fix: see map loaded but markers not showing up
4) after fix: see map loaded and markers show up as expected.