### PR TITLE
[gradle] bump dependencies versions to latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-25.0.2
+    - build-tools-25.0.3
     - android-25
     - extra-google-google_play_services
     - extra-android-m2repository

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.3.0-beta2'
+    classpath 'com.android.tools.build:gradle:2.3.2'
 
     // NOTE: Do not place your application dependencies here; they belong
     // in the individual module build.gradle files

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -3,7 +3,7 @@ apply from: 'gradle-maven-push.gradle'
 
 android {
   compileSdkVersion 25
-  buildToolsVersion "25.0.2"
+  buildToolsVersion "25.0.3"
 
   defaultConfig {
     minSdkVersion 14
@@ -17,7 +17,7 @@ android {
 }
 
 dependencies {
-  compile 'com.google.android.gms:play-services-maps:10.0.1'
+  compile 'com.google.android.gms:play-services-maps:10.2.4'
   compile 'com.google.maps.android:android-maps-utils:0.4'
 
   testCompile 'junit:junit:4.12'

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
   compileSdkVersion 25
-  buildToolsVersion "25.0.2"
+  buildToolsVersion "25.0.3"
 
   defaultConfig {
     applicationId "com.airbnb.airmapview.sample"
@@ -15,12 +15,17 @@ android {
   lintOptions {
     disable 'GradleCompatible'
   }
+
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_1_7
+    targetCompatibility JavaVersion.VERSION_1_7
+  }
 }
 
 dependencies {
   compile project(':library')
   compile 'com.android.support:multidex:1.0.1'
-  compile 'com.android.support:recyclerview-v7:25.1.0'
-  compile 'com.android.support:appcompat-v7:25.1.0'
-  compile 'com.google.android.gms:play-services:10.0.1'
+  compile 'com.android.support:recyclerview-v7:25.3.1'
+  compile 'com.android.support:appcompat-v7:25.3.1'
+  compile 'com.google.android.gms:play-services-maps:10.2.4'
 }


### PR DESCRIPTION
Bump gradle dependencies to their latest versions so we can build the app in newer versions of AS

@felipecsl @petzel 