### PR TITLE
Allow Zoom Control & Location Button Customization

### DIFF
--- a/library/src/main/java/com/airbnb/android/airmapview/AirMapInterface.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/AirMapInterface.java
@@ -161,8 +161,20 @@ public interface AirMapInterface {
   /** Enable an indicator for the user's location on the map. */
   void setMyLocationEnabled(boolean enabled);
 
-  /** Check if the user location is being tracked and shown on te map. */
+  /** Check if the user location is being tracked and shown on the map. */
   boolean isMyLocationEnabled();
+  
+  /** Check if the zoom controls are enabled and shown on the map. */
+  boolean isZoomControlsEnabled();
+  
+  /** Check if the my location button is enabled and shown on the map */
+  boolean isMyLocationButtonEnabled();
+  
+  /** Enable or disable the zoom controls determining whether they're shown */
+  void setZoomControlsEnabled(boolean enabled);
+  
+  /** Enable or disable the my location button determining whether it's shown */
+  void setMyLocationButtonEnabled(boolean enabled);
 
   /** Enable a toolbar that displays various context-dependent actions. */
   void setMapToolbarEnabled(boolean enabled);

--- a/library/src/main/java/com/airbnb/android/airmapview/NativeGoogleMapFragment.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/NativeGoogleMapFragment.java
@@ -264,11 +264,7 @@ public class NativeGoogleMapFragment extends SupportMapFragment implements AirMa
   }
 
   @Override public void setMyLocationEnabled(boolean enabled) {
-    if (myLocationEnabled != enabled) {
-      if (RuntimePermissionUtils.checkLocationPermissions(getActivity(), this)) {
-        myLocationEnabled = enabled;
-      }
-    }
+    myLocationEnabled = enabled;
   }
 
   @Override public void onLocationPermissionsGranted() {

--- a/library/src/main/java/com/airbnb/android/airmapview/NativeGoogleMapFragment.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/NativeGoogleMapFragment.java
@@ -69,9 +69,6 @@ public class NativeGoogleMapFragment extends SupportMapFragment implements AirMa
       @Override public void onMapReady(GoogleMap googleMap) {
         if (googleMap != null && getActivity() != null) {
           NativeGoogleMapFragment.this.googleMap = googleMap;
-          UiSettings settings = NativeGoogleMapFragment.this.googleMap.getUiSettings();
-          settings.setZoomControlsEnabled(false);
-          settings.setMyLocationButtonEnabled(false);
           setMyLocationEnabled(myLocationEnabled);
 
           if (onMapLoadedListener != null) {
@@ -287,6 +284,22 @@ public class NativeGoogleMapFragment extends SupportMapFragment implements AirMa
 
   @Override public boolean isMyLocationEnabled() {
     return googleMap.isMyLocationEnabled();
+  }
+
+  @Override public boolean isZoomControlsEnabled() {
+    return googleMap.getUiSettings().isZoomControlsEnabled();
+  }
+  
+  @Override public boolean isMyLocationButtonEnabled() {
+    return googleMap.getUiSettings().isMyLocationButtonEnabled();
+  }
+  
+  @Override public void setZoomControlsEnabled(boolean enabled) {
+    googleMap.getUiSettings().setZoomControlsEnabled(enabled);
+  }
+  
+  @Override public void setMyLocationButtonEnabled(boolean enabled) {
+    googleMap.getUiSettings().setMyLocationButtonEnabled(enabled);
   }
 
   @Override public void setMapToolbarEnabled(boolean enabled) {

--- a/library/src/main/java/com/airbnb/android/airmapview/WebViewMapFragment.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/WebViewMapFragment.java
@@ -241,6 +241,24 @@ public abstract class WebViewMapFragment extends Fragment implements AirMapInter
   @Override public boolean isMyLocationEnabled() {
     return trackUserLocation;
   }
+  
+  @Override public boolean isZoomControlsEnabled() {
+    // no-op
+    return false;
+  }
+   
+  @Override public boolean isMyLocationButtonEnabled() {
+    // no-op
+    return false;
+  }
+  
+  @Override public void setZoomControlsEnabled(boolean enabled) {
+     // no-op
+  }
+  
+  @Override public void setMyLocationButtonEnabled(boolean enabled) {
+    // no-op
+  }
 
   @Override public void setMapToolbarEnabled(boolean enabled) {
     // no-op


### PR DESCRIPTION
Allowing the user to set not only `MyLocationEnabled` but also `ZoomControlsEnabled` and `MyLocationButtonEnabled`

Attempts to address https://github.com/airbnb/AirMapView/issues/103