### PR TITLE
Supply permission callback

### DIFF
--- a/library/src/main/java/com/airbnb/android/airmapview/AirMapInterface.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/AirMapInterface.java
@@ -1,9 +1,12 @@
 package com.airbnb.android.airmapview;
 
+import android.support.annotation.NonNull;
+
 import com.airbnb.android.airmapview.listeners.InfoWindowCreator;
 import com.airbnb.android.airmapview.listeners.OnCameraChangeListener;
 import com.airbnb.android.airmapview.listeners.OnInfoWindowClickListener;
 import com.airbnb.android.airmapview.listeners.OnLatLngScreenLocationCallback;
+import com.airbnb.android.airmapview.listeners.OnLocationPermissionListener;
 import com.airbnb.android.airmapview.listeners.OnMapBoundsCallback;
 import com.airbnb.android.airmapview.listeners.OnMapClickListener;
 import com.airbnb.android.airmapview.listeners.OnMapLoadedListener;
@@ -57,6 +60,23 @@ public interface AirMapInterface {
    *                 instance
    */
   void setOnInfoWindowClickListener(OnInfoWindowClickListener listener);
+
+  /**
+   * Set the callback for permission request
+   *
+   * @param listener {@link com.airbnb.android.airmapview.listeners.OnLocationPermissionListener}
+   *                 instance
+   */
+  void setOnLocationPermissionListener(OnLocationPermissionListener listener);
+
+  /**
+   * Check the result of location permission request
+   *
+   * @param requestCode
+   * @param permissions
+   * @param grantResults
+   */
+  void onCheckLocationPermissionResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults);
 
   /**
    * Specific to Google Play Services maps. Sets the {@link GoogleMap.InfoWindowAdapter} and {@link
@@ -189,6 +209,16 @@ public interface AirMapInterface {
    * permissions should be executed here.
    */
   void onLocationPermissionsGranted();
+
+  /**
+   * Getting called when runtime location permissions got denied.
+   */
+  void onLocationPermissionsDenied();
+
+  /**
+   * Getting called when runtime location permissions got denied and checked the box of 'Never Ask Again'.
+   */
+  void onLocationPermissionsNeverAskAgain();
 
   /**
    * Add the given polygon to the map

--- a/library/src/main/java/com/airbnb/android/airmapview/AirMapView.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/AirMapView.java
@@ -13,6 +13,7 @@ import com.airbnb.android.airmapview.listeners.OnCameraChangeListener;
 import com.airbnb.android.airmapview.listeners.OnCameraMoveListener;
 import com.airbnb.android.airmapview.listeners.OnInfoWindowClickListener;
 import com.airbnb.android.airmapview.listeners.OnLatLngScreenLocationCallback;
+import com.airbnb.android.airmapview.listeners.OnLocationPermissionListener;
 import com.airbnb.android.airmapview.listeners.OnMapBoundsCallback;
 import com.airbnb.android.airmapview.listeners.OnMapClickListener;
 import com.airbnb.android.airmapview.listeners.OnMapInitializedListener;
@@ -41,6 +42,7 @@ public class AirMapView extends FrameLayout
   private OnMapMarkerDragListener onMapMarkerDragListener;
   private OnMapClickListener onMapClickListener;
   private OnInfoWindowClickListener onInfoWindowClickListener;
+  private OnLocationPermissionListener onLocationPermissionListener;
 
   public AirMapView(Context context) {
     super(context);
@@ -348,6 +350,14 @@ public class AirMapView extends FrameLayout
     mapInterface.setMyLocationEnabled(trackUserLocation);
   }
 
+  public void setOnLocationPermissionListener(OnLocationPermissionListener listener) {
+    onLocationPermissionListener = listener;
+  }
+
+  public void onCheckLocationPermissionResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+    mapInterface.onCheckLocationPermissionResult(requestCode, permissions, grantResults);
+  }
+
   @Override public void onCameraChanged(LatLng latLng, int zoom) {
     if (onCameraChangeListener != null) {
       onCameraChangeListener.onCameraChanged(latLng, zoom);
@@ -409,6 +419,7 @@ public class AirMapView extends FrameLayout
       mapInterface.setOnMarkerClickListener(this);
       mapInterface.setOnMarkerDragListener(this);
       mapInterface.setOnInfoWindowClickListener(this);
+      mapInterface.setOnLocationPermissionListener(onLocationPermissionListener);
 
       if (onMapInitializedListener != null) {
         // only send map Initialized callback if map initialized successfully

--- a/library/src/main/java/com/airbnb/android/airmapview/NativeGoogleMapFragment.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/NativeGoogleMapFragment.java
@@ -12,6 +12,7 @@ import com.airbnb.android.airmapview.listeners.InfoWindowCreator;
 import com.airbnb.android.airmapview.listeners.OnCameraChangeListener;
 import com.airbnb.android.airmapview.listeners.OnInfoWindowClickListener;
 import com.airbnb.android.airmapview.listeners.OnLatLngScreenLocationCallback;
+import com.airbnb.android.airmapview.listeners.OnLocationPermissionListener;
 import com.airbnb.android.airmapview.listeners.OnMapBoundsCallback;
 import com.airbnb.android.airmapview.listeners.OnMapClickListener;
 import com.airbnb.android.airmapview.listeners.OnMapLoadedListener;
@@ -42,6 +43,7 @@ import java.util.Map;
 public class NativeGoogleMapFragment extends SupportMapFragment implements AirMapInterface {
   private GoogleMap googleMap;
   private OnMapLoadedListener onMapLoadedListener;
+  private OnLocationPermissionListener onLocationPermissionListener;
   private boolean myLocationEnabled;
   private GeoJsonLayer layerOnMap;
   private final Map<Marker, AirMapMarker<?>> markers = new HashMap<>();
@@ -119,6 +121,10 @@ public class NativeGoogleMapFragment extends SupportMapFragment implements AirMa
         }
       }
     });
+  }
+
+  @Override public void setOnLocationPermissionListener(final OnLocationPermissionListener listener) {
+    this.onLocationPermissionListener = listener;
   }
 
   @Override public void setInfoWindowCreator(GoogleMap.InfoWindowAdapter adapter,
@@ -267,22 +273,47 @@ public class NativeGoogleMapFragment extends SupportMapFragment implements AirMa
   }
 
   @Override public void setMyLocationEnabled(boolean enabled) {
-    if (myLocationEnabled != enabled) {
-      if (RuntimePermissionUtils.checkLocationPermissions(getActivity(), this)) {
-        myLocationEnabled = enabled;
-      }
+    myLocationEnabled = enabled;
+    if (enabled) {
+      RuntimePermissionUtils.checkLocationPermissions(getActivity(), this);
     }
   }
 
   @Override public void onLocationPermissionsGranted() {
-    //noinspection MissingPermission
-    googleMap.setMyLocationEnabled(myLocationEnabled);
+    myLocationEnabled = true;
+    googleMap.setMyLocationEnabled(true);
+    if (onLocationPermissionListener != null) {
+      onLocationPermissionListener.onLocationPermissionGranted();
+    }
+  }
+
+  @Override
+  public void onLocationPermissionsDenied() {
+    myLocationEnabled = false;
+    googleMap.setMyLocationEnabled(false);
+    if (onLocationPermissionListener != null) {
+      onLocationPermissionListener.onLocationPermissionDenied();
+    }
+  }
+
+  @Override
+  public void onLocationPermissionsNeverAskAgain() {
+    myLocationEnabled = false;
+    googleMap.setMyLocationEnabled(false);
+    if (onLocationPermissionListener != null) {
+      onLocationPermissionListener.onLocationPermissionPermanentlyDenied();
+    }
   }
 
   @Override public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
       @NonNull int[] grantResults) {
     super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-    RuntimePermissionUtils.onRequestPermissionsResult(this, requestCode, grantResults);
+    RuntimePermissionUtils.onRequestPermissionsResult(this.getActivity(), this, requestCode, permissions, grantResults);
+  }
+
+  @Override
+  public void onCheckLocationPermissionResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+    RuntimePermissionUtils.onRequestPermissionsResult(this.getActivity(), this, requestCode, permissions, grantResults);
   }
 
   @Override public boolean isMyLocationEnabled() {

--- a/library/src/main/java/com/airbnb/android/airmapview/RuntimePermissionUtils.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/RuntimePermissionUtils.java
@@ -6,12 +6,16 @@ import android.content.pm.PackageManager;
 import android.os.Build;
 import android.support.v4.app.ActivityCompat;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 import static android.support.v4.content.PermissionChecker.checkSelfPermission;
 
 /**
  * Utility class that handles runtime permissions
  */
-final class RuntimePermissionUtils {
+public final class RuntimePermissionUtils {
 
   private RuntimePermissionUtils() {
   }
@@ -33,6 +37,27 @@ final class RuntimePermissionUtils {
       }
     }
     return true;
+  }
+
+    /**
+     * Check the permissions are the requested permissions
+     *
+     * @param permissions
+     * @return true if the permissions are matched perfectly
+     */
+  static boolean isRequestedPermission(String[] permissions) {
+      if (permissions.length != LOCATION_PERMISSIONS.length) {
+          return false;
+      }
+
+      final Set<String> requestPermissions = new HashSet<>(Arrays.asList(LOCATION_PERMISSIONS));
+      for (String permission : permissions) {
+          if (!requestPermissions.contains(permission)) {
+              return false;
+          }
+      }
+
+      return true;
   }
 
   /**
@@ -68,31 +93,41 @@ final class RuntimePermissionUtils {
    *
    * @param airMapInterface the callback interface if permission is granted.
    */
-  static boolean checkLocationPermissions(Activity targetActivity, AirMapInterface airMapInterface) {
+  static void checkLocationPermissions(Activity targetActivity, AirMapInterface airMapInterface) {
     if (hasSelfPermissions(targetActivity, LOCATION_PERMISSIONS)) {
       airMapInterface.onLocationPermissionsGranted();
-      return true;
     } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
       targetActivity.requestPermissions(LOCATION_PERMISSIONS, LOCATION_PERMISSION_REQUEST_CODE);
+    } else {
+      airMapInterface.onLocationPermissionsDenied();
     }
-    //else don't have location permissions in pre M, don't do anything.
-    return false;
   }
 
   /**
-   * Dispatch actions based off requested permission results.<br />
+   * Dispatch actions based off requested permission results.
+   * The activity or fragment must call this function in onRequestPermissionsResult
+   * {@link android.support.v4.app.Fragment#onRequestPermissionsResult(int, String[], int[])}
+   * {@link android.app.Activity#onRequestPermissionsResult(int, String[], int[])}<br />
    * Further actions like
    * 1> Rationale: showing a snack bar to explain why the permissions are needed and
    * 2> Denied: adding airMapInterface.onLocationPermissionsDenied()
    * should be added here if needed.
    *
    */
-  static void onRequestPermissionsResult(AirMapInterface airMapInterface, int requestCode,
-          int[] grantResults) {
+  public static void onRequestPermissionsResult(Activity activity, AirMapInterface airMapInterface, int requestCode,
+                                                String[] permissions, int[] grantResults) {
     switch (requestCode) {
       case LOCATION_PERMISSION_REQUEST_CODE:
+        if (!isRequestedPermission(permissions)) {
+          break;
+        }
+
         if (verifyPermissions(grantResults)) {
           airMapInterface.onLocationPermissionsGranted();
+        } else if (!shouldShowRequestPermissionRationale(activity, LOCATION_PERMISSIONS)) {
+            airMapInterface.onLocationPermissionsNeverAskAgain();
+        } else {
+            airMapInterface.onLocationPermissionsDenied();
         }
         break;
       default:

--- a/library/src/main/java/com/airbnb/android/airmapview/listeners/OnLocationPermissionListener.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/listeners/OnLocationPermissionListener.java
@@ -1,0 +1,7 @@
+package com.airbnb.android.airmapview.listeners;
+
+public interface OnLocationPermissionListener {
+    void onLocationPermissionGranted();
+    void onLocationPermissionDenied();
+    void onLocationPermissionPermanentlyDenied();
+}

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
   <!-- not needed as of api 23 -->
   <!--

--- a/sample/src/main/java/com/airbnb/airmapview/sample/MainActivity.java
+++ b/sample/src/main/java/com/airbnb/airmapview/sample/MainActivity.java
@@ -25,11 +25,13 @@ import com.airbnb.android.airmapview.AirMapViewTypes;
 import com.airbnb.android.airmapview.DefaultAirMapViewBuilder;
 import com.airbnb.android.airmapview.GoogleChinaMapType;
 import com.airbnb.android.airmapview.MapType;
+import com.airbnb.android.airmapview.RuntimePermissionUtils;
 import com.airbnb.android.airmapview.WebAirMapViewBuilder;
 import com.airbnb.android.airmapview.listeners.OnCameraChangeListener;
 import com.airbnb.android.airmapview.listeners.OnCameraMoveListener;
 import com.airbnb.android.airmapview.listeners.OnInfoWindowClickListener;
 import com.airbnb.android.airmapview.listeners.OnLatLngScreenLocationCallback;
+import com.airbnb.android.airmapview.listeners.OnLocationPermissionListener;
 import com.airbnb.android.airmapview.listeners.OnMapClickListener;
 import com.airbnb.android.airmapview.listeners.OnMapInitializedListener;
 import com.airbnb.android.airmapview.listeners.OnMapMarkerClickListener;
@@ -43,7 +45,7 @@ import java.util.Arrays;
 public class MainActivity extends AppCompatActivity
     implements OnCameraChangeListener, OnMapInitializedListener,
     OnMapClickListener, OnCameraMoveListener, OnMapMarkerClickListener,
-    OnInfoWindowClickListener, OnLatLngScreenLocationCallback {
+    OnInfoWindowClickListener, OnLatLngScreenLocationCallback, OnLocationPermissionListener {
 
   private final LogsAdapter adapter = new LogsAdapter();
 
@@ -89,6 +91,7 @@ public class MainActivity extends AppCompatActivity
     map.setOnMarkerClickListener(this);
     map.setOnMapInitializedListener(this);
     map.setOnInfoWindowClickListener(this);
+    map.setOnLocationPermissionListener(this);
     map.initialize(getSupportFragmentManager());
   }
 
@@ -255,5 +258,26 @@ public class MainActivity extends AppCompatActivity
 
   @Override public void onLatLngScreenLocationReady(Point point) {
     appendLog("LatLng location on screen (x,y): (" + point.x + "," + point.y + ")");
+  }
+
+  @Override
+  public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+    super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+    map.onCheckLocationPermissionResult(requestCode, permissions, grantResults);
+  }
+
+  @Override
+  public void onLocationPermissionGranted() {
+    Toast.makeText(this, "Permission is granted", Toast.LENGTH_SHORT).show();
+  }
+
+  @Override
+  public void onLocationPermissionDenied() {
+    Toast.makeText(this, "Permission is denied", Toast.LENGTH_SHORT).show();
+  }
+
+  @Override
+  public void onLocationPermissionPermanentlyDenied() {
+    Toast.makeText(this, "Permission is permanently denied", Toast.LENGTH_SHORT).show();
   }
 }


### PR DESCRIPTION
### Descriptions:
Supply the permission callbacks.
1. Supply the denied and neverAskAgain callback
2. Supply `onCheckLocationPermissionResult`, since `onRequestPermissionsResult` in NativeGoogleMapFragment and WebviewMapFragment won't be called when `requestPermissions`.

### Test:
Tested with Sample app

### Reviewers:
@felipecsl @gpeal @nwadams 
