### PR TITLE
[native] Fix enabling location and show location button

### DIFF
--- a/library/src/main/java/com/airbnb/android/airmapview/AirMapInterface.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/AirMapInterface.java
@@ -164,6 +164,9 @@ public interface AirMapInterface {
   /** Check if the user location is being tracked and shown on te map. */
   boolean isMyLocationEnabled();
 
+  /** Enable a button for centering on user location button. Works with GooglePlay Services maps. */
+  void setMyLocationButtonEnabled(boolean enabled);
+
   /** Enable a toolbar that displays various context-dependent actions. */
   void setMapToolbarEnabled(boolean enabled);
 

--- a/library/src/main/java/com/airbnb/android/airmapview/AirMapView.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/AirMapView.java
@@ -348,6 +348,10 @@ public class AirMapView extends FrameLayout
     mapInterface.setMyLocationEnabled(trackUserLocation);
   }
 
+  public void setMyLocationButtonEnabled(boolean enabled) {
+    mapInterface.setMyLocationButtonEnabled(enabled);
+  }
+
   @Override public void onCameraChanged(LatLng latLng, int zoom) {
     if (onCameraChangeListener != null) {
       onCameraChangeListener.onCameraChanged(latLng, zoom);

--- a/library/src/main/java/com/airbnb/android/airmapview/NativeGoogleMapFragment.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/NativeGoogleMapFragment.java
@@ -268,8 +268,9 @@ public class NativeGoogleMapFragment extends SupportMapFragment implements AirMa
 
   @Override public void setMyLocationEnabled(boolean enabled) {
     if (myLocationEnabled != enabled) {
-      if (RuntimePermissionUtils.checkLocationPermissions(getActivity(), this)) {
-        myLocationEnabled = enabled;
+      myLocationEnabled = enabled;
+      if (!RuntimePermissionUtils.checkLocationPermissions(getActivity(), this)) {
+        myLocationEnabled = false;
       }
     }
   }
@@ -287,6 +288,10 @@ public class NativeGoogleMapFragment extends SupportMapFragment implements AirMa
 
   @Override public boolean isMyLocationEnabled() {
     return googleMap.isMyLocationEnabled();
+  }
+
+  @Override public void setMyLocationButtonEnabled(boolean enabled) {
+    googleMap.getUiSettings().setMyLocationButtonEnabled(enabled);
   }
 
   @Override public void setMapToolbarEnabled(boolean enabled) {

--- a/library/src/main/java/com/airbnb/android/airmapview/WebViewMapFragment.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/WebViewMapFragment.java
@@ -241,6 +241,10 @@ public abstract class WebViewMapFragment extends Fragment implements AirMapInter
     return trackUserLocation;
   }
 
+  @Override public void setMyLocationButtonEnabled(boolean enabled) {
+    // no-op
+  }
+
   @Override public void setMapToolbarEnabled(boolean enabled) {
     // no-op
   }


### PR DESCRIPTION
## Change summary:
`onLocationPermissionsGranted` is called only when location permissions were granted.  We should set location enabled as true and show the location button.

tested on the sample app

## How was it tested?
- [X] Built and ran on simulator
- [X] Built and ran on device

## Please review:
@felipecsl

![screenshot_20171212-151411](https://user-images.githubusercontent.com/2802702/33906382-a06b2796-df36-11e7-8924-5ed3c369e4ab.png)



