### PR TITLE
Updated compile to implementation in gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ will fallback to a web based map provider (currently Google Maps). Easy to integ
 Grab via Gradle:
 
 ```groovy
-compile 'com.airbnb.android:airmapview:1.8.0'
+implementation 'com.airbnb.android:airmapview:1.8.0'
 ```
 
 Snapshots of the development version are available in [Sonatype's `snapshots` repository](https://oss.sonatype.org/content/repositories/snapshots/).


### PR DESCRIPTION
`compile` has been deprecated and replaced by `implementation` at the end of 2018