### PR TITLE
Allow you to handle your marker click event

### DIFF
--- a/library/src/main/java/com/airbnb/android/airmapview/AirMapView.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/AirMapView.java
@@ -371,6 +371,14 @@ public class AirMapView extends FrameLayout
     }
   }
 
+  @Override public boolean onMakerClickEventIsHandled() {
+    if (onMapMarkerClickListener != null) {
+      return onMapMarkerClickListener.onMakerClickEventIsHandled();
+    } else {
+      return false;
+    }
+  }
+
   @Override public void onMapMarkerDragStart(Marker marker) {
     if (onMapMarkerDragListener != null) {
       onMapMarkerDragListener.onMapMarkerDragStart(marker);

--- a/library/src/main/java/com/airbnb/android/airmapview/AirMapView.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/AirMapView.java
@@ -365,15 +365,9 @@ public class AirMapView extends FrameLayout
     }
   }
 
-  @Override public void onMapMarkerClick(AirMapMarker<?> airMarker) {
+  @Override public boolean onMapMarkerClick(AirMapMarker<?> airMarker) {
     if (onMapMarkerClickListener != null) {
-      onMapMarkerClickListener.onMapMarkerClick(airMarker);
-    }
-  }
-
-  @Override public boolean onMakerClickEventIsHandled() {
-    if (onMapMarkerClickListener != null) {
-      return onMapMarkerClickListener.onMakerClickEventIsHandled();
+      return onMapMarkerClickListener.onMapMarkerClick(airMarker);
     } else {
       return false;
     }

--- a/library/src/main/java/com/airbnb/android/airmapview/NativeGoogleMapFragment.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/NativeGoogleMapFragment.java
@@ -225,7 +225,7 @@ public class NativeGoogleMapFragment extends SupportMapFragment implements AirMa
         if (airMarker != null) {
           listener.onMapMarkerClick(airMarker);
         }
-        return false;
+        return listener.onMakerClickEventIsHandled();
       }
     });
   }

--- a/library/src/main/java/com/airbnb/android/airmapview/NativeGoogleMapFragment.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/NativeGoogleMapFragment.java
@@ -223,9 +223,9 @@ public class NativeGoogleMapFragment extends SupportMapFragment implements AirMa
       @Override public boolean onMarkerClick(Marker marker) {
         AirMapMarker<?> airMarker = markers.get(marker);
         if (airMarker != null) {
-          listener.onMapMarkerClick(airMarker);
+          return listener.onMapMarkerClick(airMarker);
         }
-        return listener.onMakerClickEventIsHandled();
+        return false;
       }
     });
   }

--- a/library/src/main/java/com/airbnb/android/airmapview/listeners/OnMapMarkerClickListener.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/listeners/OnMapMarkerClickListener.java
@@ -3,7 +3,5 @@ package com.airbnb.android.airmapview.listeners;
 import com.airbnb.android.airmapview.AirMapMarker;
 
 public interface OnMapMarkerClickListener {
-  void onMapMarkerClick(AirMapMarker<?> airMarker);
-
-  boolean onMakerClickEventIsHandled();
+  boolean onMapMarkerClick(AirMapMarker<?> airMarker);
 }

--- a/library/src/main/java/com/airbnb/android/airmapview/listeners/OnMapMarkerClickListener.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/listeners/OnMapMarkerClickListener.java
@@ -3,5 +3,13 @@ package com.airbnb.android.airmapview.listeners;
 import com.airbnb.android.airmapview.AirMapMarker;
 
 public interface OnMapMarkerClickListener {
+
+  /*
+  * Called when an airMarker has been clicked or tapped.
+  * Return true if the listener has consumed the event (i.e., the default behavior should not occur);
+  * false otherwise (i.e., the default behavior should occur).
+  * The default behavior is for the camera to move to the marker and an info window to appear.
+  * See: https://developers.google.com/android/reference/com/google/android/gms/maps/GoogleMap.OnMarkerClickListener
+  * */
   boolean onMapMarkerClick(AirMapMarker<?> airMarker);
 }

--- a/library/src/main/java/com/airbnb/android/airmapview/listeners/OnMapMarkerClickListener.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/listeners/OnMapMarkerClickListener.java
@@ -4,4 +4,6 @@ import com.airbnb.android.airmapview.AirMapMarker;
 
 public interface OnMapMarkerClickListener {
   void onMapMarkerClick(AirMapMarker<?> airMarker);
+
+  boolean onMakerClickEventIsHandled();
 }

--- a/sample/src/main/java/com/airbnb/airmapview/sample/MainActivity.java
+++ b/sample/src/main/java/com/airbnb/airmapview/sample/MainActivity.java
@@ -35,13 +35,11 @@ import com.airbnb.android.airmapview.listeners.OnCameraChangeListener;
 import com.airbnb.android.airmapview.listeners.OnCameraMoveListener;
 import com.airbnb.android.airmapview.listeners.OnInfoWindowClickListener;
 import com.airbnb.android.airmapview.listeners.OnLatLngScreenLocationCallback;
-import com.airbnb.android.airmapview.listeners.OnMapBoundsCallback;
 import com.airbnb.android.airmapview.listeners.OnMapClickListener;
 import com.airbnb.android.airmapview.listeners.OnMapInitializedListener;
 import com.airbnb.android.airmapview.listeners.OnMapMarkerClickListener;
 import com.airbnb.android.airmapview.listeners.OnSnapshotReadyListener;
 import com.google.android.gms.maps.model.LatLng;
-import com.google.android.gms.maps.model.LatLngBounds;
 
 import org.json.JSONException;
 

--- a/sample/src/main/java/com/airbnb/airmapview/sample/MainActivity.java
+++ b/sample/src/main/java/com/airbnb/airmapview/sample/MainActivity.java
@@ -299,8 +299,9 @@ public class MainActivity extends AppCompatActivity
     logsRecyclerView.smoothScrollToPosition(adapter.getItemCount() - 1);
   }
 
-  @Override public void onMapMarkerClick(AirMapMarker<?> airMarker) {
+  @Override public boolean onMapMarkerClick(AirMapMarker<?> airMarker) {
     appendLog("Map onMapMarkerClick triggered with id " + airMarker.getId());
+    return false;
   }
 
   @Override public void onInfoWindowClick(AirMapMarker<?> airMarker) {
@@ -311,7 +312,4 @@ public class MainActivity extends AppCompatActivity
     appendLog("LatLng location on screen (x,y): (" + point.x + "," + point.y + ")");
   }
 
-  @Override public boolean onMakerClickEventIsHandled() {
-    return true;
-  }
 }

--- a/sample/src/main/java/com/airbnb/airmapview/sample/MainActivity.java
+++ b/sample/src/main/java/com/airbnb/airmapview/sample/MainActivity.java
@@ -35,11 +35,13 @@ import com.airbnb.android.airmapview.listeners.OnCameraChangeListener;
 import com.airbnb.android.airmapview.listeners.OnCameraMoveListener;
 import com.airbnb.android.airmapview.listeners.OnInfoWindowClickListener;
 import com.airbnb.android.airmapview.listeners.OnLatLngScreenLocationCallback;
+import com.airbnb.android.airmapview.listeners.OnMapBoundsCallback;
 import com.airbnb.android.airmapview.listeners.OnMapClickListener;
 import com.airbnb.android.airmapview.listeners.OnMapInitializedListener;
 import com.airbnb.android.airmapview.listeners.OnMapMarkerClickListener;
 import com.airbnb.android.airmapview.listeners.OnSnapshotReadyListener;
 import com.google.android.gms.maps.model.LatLng;
+import com.google.android.gms.maps.model.LatLngBounds;
 
 import org.json.JSONException;
 
@@ -309,5 +311,9 @@ public class MainActivity extends AppCompatActivity
 
   @Override public void onLatLngScreenLocationReady(Point point) {
     appendLog("LatLng location on screen (x,y): (" + point.x + "," + point.y + ")");
+  }
+
+  @Override public boolean onMakerClickEventIsHandled() {
+    return true;
   }
 }

--- a/sample/src/main/java/com/airbnb/airmapview/sample/MainActivity.java
+++ b/sample/src/main/java/com/airbnb/airmapview/sample/MainActivity.java
@@ -311,5 +311,4 @@ public class MainActivity extends AppCompatActivity
   @Override public void onLatLngScreenLocationReady(Point point) {
     appendLog("LatLng location on screen (x,y): (" + point.x + "," + point.y + ")");
   }
-
 }


### PR DESCRIPTION
This PR allows adds an option for users to handle `onMarkerClick()` event, so that the default behavior should not occur. The default behavior is for the camera to move to the marker once it's clicked. (https://developers.google.com/android/reference/com/google/android/gms/maps/GoogleMap.OnMarkerClickListener). This is a breaking change because it requires people who uses this library to implement `onMarkerClickEventIsHandled()`

I'm making a change for Explore Map to disable the behavior where the map centers on a marker once it's clicked. This is how this change looks on the demo map. Note that the map doesn't center on the markers when I click them. 

![allowing the client to handle click listener](https://user-images.githubusercontent.com/7671851/61409671-941d7f80-a897-11e9-8c38-b72b4ddce670.gif)


