### PR TITLE
Add support for leaflet map animation center

### DIFF
--- a/library/src/main/assets/leaflet_map.html
+++ b/library/src/main/assets/leaflet_map.html
@@ -282,6 +282,11 @@ function centerMap(lat, lng) {
   map.panTo(paddingLatLngFromLatLng(L.latLng(latLng[0], latLng[1])));
 }
 
+function animateCenterMap(lat, lng) {
+  var latLng = convertLatLng([lat, lng]);
+  map.flyTo(paddingLatLngFromLatLng(L.latLng(latLng[0], latLng[1])));
+}
+
 function setZoom(zoom) {
   map.setZoom(zoom);
 }

--- a/library/src/main/java/com/airbnb/android/airmapview/LeafletWebViewMapFragment.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/LeafletWebViewMapFragment.java
@@ -42,4 +42,16 @@ public class LeafletWebViewMapFragment extends WebViewMapFragment {
               marker.getDivIcon().getHeight()));
     }
   }
+
+  @Override
+  public void animateCenter(LatLng latLng) {
+    webView.loadUrl(String.format(Locale.US, "javascript:animateCenterMap(%1$f, %2$f);", latLng.latitude,
+            latLng.longitude));
+  }
+
+  @Override
+  public void animateCenterZoom(LatLng latLng, int zoom) {
+    animateCenter(latLng);
+    setZoom(zoom);
+  }
 }


### PR DESCRIPTION
leaflet map override `animateCenter`  to support animation

![fly](https://user-images.githubusercontent.com/31537332/63916620-5fdad880-ca6b-11e9-9052-9be07f73aa2a.gif)

@bobby1i @nwadams 