### PR TITLE
Fix bugs of leaflet map about padding

### DIFF
--- a/library/src/main/assets/leaflet_map.html
+++ b/library/src/main/assets/leaflet_map.html
@@ -265,20 +265,20 @@ function setBounds(neLat, neLng, swLat, swLng) {
 
 function paddingLatLngFromLatLng(latlng, zoom) {
   var point = map.project(latlng, zoom);
-  point.x = point.x - (paddingLeft - paddingRight) / 2
+  point.x = point.x - (paddingLeft - paddingRight) / 2;
   point.y = point.y - (paddingTop - paddingBottom) / 2;
   return map.unproject(point, zoom);
 }
 
 function latLngFromPaddingLatLng(latlng, zoom) {
   var point = map.project(latlng, zoom);
-  point.x = point.x + (paddingLeft - paddingRight) / 2
+  point.x = point.x + (paddingLeft - paddingRight) / 2;
   point.y = point.y + (paddingTop - paddingBottom) / 2;
   return map.unproject(point, zoom);
 }
 
 function centerMap(lat, lng) {
-  centerZoomMap(lat, lng, map.getZoom())
+  centerZoomMap(lat, lng, map.getZoom());
 }
 
 function centerZoomMap(lat, lng, zoom) {
@@ -296,7 +296,7 @@ function animateCenterZoomMap(lat, lng, zoom) {
 }
 
 function setZoom(zoom) {
-  map.setZoomAround(getPaddingCenter(), zoom)
+  map.setZoomAround(getPaddedCenter(), zoom);
 }
 
 function icon(highlight) {
@@ -485,7 +485,7 @@ function mapMove() {
   }
   // javascript bridge not fast enough to handle events immediately.
   moveTimeout = setTimeout(function() {
-    var latLng = getPaddingCenter();
+    var latLng = getPaddedCenter();
     if (latLng != null) {
       var convertedLatLng = reverseConvertLatLng([ latLng.lat, latLng.lng ]);
       AirMapView.mapMove(convertedLatLng[0], convertedLatLng[1], map.getZoom());
@@ -494,14 +494,17 @@ function mapMove() {
 }
 
 function getCenter() {
-  var latLng = getPaddingCenter();
+  var latLng = getPaddedCenter();
   if (latLng != null) {
     var convertedLatLng = reverseConvertLatLng([ latLng.lat, latLng.lng ]);
     AirMapView.mapCenterCallback(convertedLatLng[0], convertedLatLng[1]);
   }
 }
 
-function getPaddingCenter() {
+/**
+* Get center latLng of the map view with padding
+*/
+function getPaddedCenter() {
   return latLngFromPaddingLatLng(map.getCenter(), map.getZoom());
 }
 

--- a/library/src/main/assets/leaflet_map.html
+++ b/library/src/main/assets/leaflet_map.html
@@ -263,32 +263,40 @@ function setBounds(neLat, neLng, swLat, swLng) {
   map.fitBounds(bounds);
 }
 
-function paddingLatLngFromLatLng(latLng) {
-  var centerPoint = map.latLngToContainerPoint(latLng);
-  centerPoint.x = centerPoint.x - (paddingLeft - paddingRight) / 2;
-  centerPoint.y = centerPoint.y - (paddingTop - paddingBottom) / 2;
-  return map.containerPointToLatLng(centerPoint);
+function paddingLatLngFromLatLng(latlng, zoom) {
+  var point = map.project(latlng, zoom);
+  point.x = point.x - (paddingLeft - paddingRight) / 2
+  point.y = point.y - (paddingTop - paddingBottom) / 2;
+  return map.unproject(point, zoom);
 }
 
-function latLngFromPaddingLatLng(paddingLatLng) {
-  var centerPoint = map.latLngToContainerPoint(paddingLatLng);
-  centerPoint.x = centerPoint.x + (paddingLeft - paddingRight) / 2;
-  centerPoint.y = centerPoint.y + (paddingTop - paddingBottom) / 2;
-  return map.containerPointToLatLng(centerPoint);
+function latLngFromPaddingLatLng(latlng, zoom) {
+  var point = map.project(latlng, zoom);
+  point.x = point.x + (paddingLeft - paddingRight) / 2
+  point.y = point.y + (paddingTop - paddingBottom) / 2;
+  return map.unproject(point, zoom);
 }
 
 function centerMap(lat, lng) {
+  centerZoomMap(lat, lng, map.getZoom())
+}
+
+function centerZoomMap(lat, lng, zoom) {
   var latLng = convertLatLng([lat, lng]);
-  map.panTo(paddingLatLngFromLatLng(L.latLng(latLng[0], latLng[1])));
+  map.setView(paddingLatLngFromLatLng(L.latLng(latLng[0], latLng[1]), zoom), zoom, {animate:false});
 }
 
 function animateCenterMap(lat, lng) {
+  animateCenterZoomMap(lat, lng, map.getZoom())
+}
+
+function animateCenterZoomMap(lat, lng, zoom) {
   var latLng = convertLatLng([lat, lng]);
-  map.flyTo(paddingLatLngFromLatLng(L.latLng(latLng[0], latLng[1])));
+  map.flyTo(paddingLatLngFromLatLng(L.latLng(latLng[0], latLng[1]), zoom), zoom, {duration:0.5});
 }
 
 function setZoom(zoom) {
-  map.setZoom(zoom);
+  map.setZoomAround(getPaddingCenter(), zoom)
 }
 
 function icon(highlight) {
@@ -477,7 +485,7 @@ function mapMove() {
   }
   // javascript bridge not fast enough to handle events immediately.
   moveTimeout = setTimeout(function() {
-    var latLng = map.getCenter();
+    var latLng = getPaddingCenter();
     if (latLng != null) {
       var convertedLatLng = reverseConvertLatLng([ latLng.lat, latLng.lng ]);
       AirMapView.mapMove(convertedLatLng[0], convertedLatLng[1], map.getZoom());
@@ -486,11 +494,15 @@ function mapMove() {
 }
 
 function getCenter() {
-  var latLng = latLngFromPaddingLatLng(map.getCenter());
+  var latLng = getPaddingCenter();
   if (latLng != null) {
     var convertedLatLng = reverseConvertLatLng([ latLng.lat, latLng.lng ]);
     AirMapView.mapCenterCallback(convertedLatLng[0], convertedLatLng[1]);
   }
+}
+
+function getPaddingCenter() {
+  return latLngFromPaddingLatLng(map.getCenter(), map.getZoom());
 }
 
 function getBounds() {
@@ -506,16 +518,14 @@ function getScreenLocation(lat, lng) {
   var latLng = convertLatLng([lat, lng]);
   var latLngObject = L.latLng(latLng[0], latLng[1]);
   var screenLocation = map.latLngToContainerPoint(latLngObject);
-  AirMapView.getLatLngScreenLocationCallback(screenLocation.x, screenLocation.y);
+  AirMapView.getLatLngScreenLocationCallback(screenLocation.x * window.devicePixelRatio, screenLocation.y * window.devicePixelRatio);
 }
 
 function setPadding(left, top, right, bottom) {
-  var centerLatLng = latLngFromPaddingLatLng(map.getCenter());
   paddingLeft = left / window.devicePixelRatio;
   paddingTop = top / window.devicePixelRatio;
   paddingRight = right / window.devicePixelRatio;
   paddingBottom = bottom / window.devicePixelRatio;
-  map.panTo(paddingLatLngFromLatLng(centerLatLng));
 }
 
 // converts an android int color to a web color :)

--- a/library/src/main/assets/leaflet_map.html
+++ b/library/src/main/assets/leaflet_map.html
@@ -502,7 +502,7 @@ function getCenter() {
 }
 
 /**
-* Get center latLng of the map view with padding
+* Returns the center LatLng of the map view with padding
 */
 function getPaddedCenter() {
   return latLngFromPaddingLatLng(map.getCenter(), map.getZoom());

--- a/library/src/main/assets/leaflet_map.html
+++ b/library/src/main/assets/leaflet_map.html
@@ -287,7 +287,7 @@ function centerZoomMap(lat, lng, zoom) {
 }
 
 function animateCenterMap(lat, lng) {
-  animateCenterZoomMap(lat, lng, map.getZoom())
+  animateCenterZoomMap(lat, lng, map.getZoom());
 }
 
 function animateCenterZoomMap(lat, lng, zoom) {

--- a/library/src/main/java/com/airbnb/android/airmapview/LeafletWebViewMapFragment.java
+++ b/library/src/main/java/com/airbnb/android/airmapview/LeafletWebViewMapFragment.java
@@ -44,6 +44,12 @@ public class LeafletWebViewMapFragment extends WebViewMapFragment {
   }
 
   @Override
+  public void setCenterZoom(LatLng latLng, int zoom) {
+    webView.loadUrl(String.format(Locale.US, "javascript:centerZoomMap(%1$f, %2$f, %3$d);", latLng.latitude,
+            latLng.longitude, zoom));
+  }
+
+  @Override
   public void animateCenter(LatLng latLng) {
     webView.loadUrl(String.format(Locale.US, "javascript:animateCenterMap(%1$f, %2$f);", latLng.latitude,
             latLng.longitude));
@@ -51,7 +57,7 @@ public class LeafletWebViewMapFragment extends WebViewMapFragment {
 
   @Override
   public void animateCenterZoom(LatLng latLng, int zoom) {
-    animateCenter(latLng);
-    setZoom(zoom);
+    webView.loadUrl(String.format(Locale.US, "javascript:animateCenterZoomMap(%1$f, %2$f, %3$d);", latLng.latitude,
+            latLng.longitude, zoom));
   }
 }

--- a/sample/src/main/java/com/airbnb/airmapview/sample/MainActivity.java
+++ b/sample/src/main/java/com/airbnb/airmapview/sample/MainActivity.java
@@ -56,6 +56,7 @@ public class MainActivity extends AppCompatActivity
   private AirMapView map;
   private DefaultAirMapViewBuilder mapViewBuilder;
   private RecyclerView logsRecyclerView;
+  private View bottomToolsView;
 
   @Override protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
@@ -63,6 +64,7 @@ public class MainActivity extends AppCompatActivity
 
     mapViewBuilder = new DefaultAirMapViewBuilder(this);
     map = findViewById(R.id.map);
+    bottomToolsView = findViewById(R.id.bottom_tools);
     logsRecyclerView = findViewById(R.id.logs);
     ((LinearLayoutManager) logsRecyclerView.getLayoutManager()).setReverseLayout(true);
     logsRecyclerView.setAdapter(adapter);
@@ -178,6 +180,27 @@ public class MainActivity extends AppCompatActivity
         break;
       case R.id.disable_location:
         map.setMyLocationEnabled(false);
+      case R.id.add_padding:
+        map.setPadding(0, 0, 0, bottomToolsView.getHeight());
+        break;
+      case R.id.center_map: {
+        LatLng wfcLatLng = new LatLng(39.918786, 116.459273);
+        map.setCenter(wfcLatLng);
+        break;
+      }
+      case R.id.animateCenter: {
+        LatLng wfcLatLng = new LatLng(39.918786, 116.459273);
+        map.animateCenter(wfcLatLng);
+        break;
+      }
+      case R.id.zoom:
+        map.setZoom(15);
+        break;
+      case R.id.animateCenterZoom: {
+        LatLng wfcLatLng = new LatLng(39.918786, 116.459273);
+        map.animateCenterZoom(wfcLatLng, 15);
+        break;
+      }
       default:
         break;
     }

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -18,39 +18,49 @@
             android:layout_height="match_parent" />
 
         <LinearLayout
+            android:id="@+id/bottom_tools"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:orientation="vertical"
             android:layout_gravity="bottom">
 
-            <Button
-                android:id="@+id/btnMapTypeNormal"
-                style="?android:attr/buttonBarButtonStyle"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Normal" />
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+                <Button
+                    android:id="@+id/btnMapTypeNormal"
+                    style="?android:attr/buttonBarButtonStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Normal" />
 
-            <Button
-                android:id="@+id/btnMapTypeSattelite"
-                style="?android:attr/buttonBarButtonStyle"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Satellite" />
+                <Button
+                    android:id="@+id/btnMapTypeSattelite"
+                    style="?android:attr/buttonBarButtonStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Satellite" />
 
-            <Button
-                android:id="@+id/btnMapTypeTerrain"
-                style="?android:attr/buttonBarButtonStyle"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Terrain" />
+                <Button
+                    android:id="@+id/btnMapTypeTerrain"
+                    style="?android:attr/buttonBarButtonStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Terrain" />
+
+            </LinearLayout>
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/logs"
+                android:layout_width="match_parent"
+                android:layout_height="200dp"
+                android:background="@android:color/white"
+                app:layoutManager="LinearLayoutManager" />
 
         </LinearLayout>
 
     </FrameLayout>
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/logs"
-        android:layout_width="match_parent"
-        android:layout_height="100dp"
-        app:layoutManager="LinearLayoutManager" />
+
 
 </LinearLayout>

--- a/sample/src/main/res/menu/menu_main.xml
+++ b/sample/src/main/res/menu/menu_main.xml
@@ -73,5 +73,30 @@
         android:orderInCategory="100"
         app:showAsAction="never"/>
 
+    <item android:id="@+id/add_padding"
+        android:title="Add Padding"
+        android:orderInCategory="100"
+        app:showAsAction="never"/>
+
+    <item android:id="@+id/center_map"
+        android:title="Center map"
+        android:orderInCategory="100"
+        app:showAsAction="never"/>
+
+    <item android:id="@+id/animateCenter"
+        android:title="Animate Center"
+        android:orderInCategory="100"
+        app:showAsAction="never"/>
+
+    <item android:id="@+id/zoom"
+        android:title="Zoom"
+        android:orderInCategory="100"
+        app:showAsAction="never"/>
+
+    <item android:id="@+id/animateCenterZoom"
+        android:title="Animate Center Zoom"
+        android:orderInCategory="100"
+        app:showAsAction="never"/>
+
 </menu>
 


### PR DESCRIPTION
Some leaflet map functions didn't work well when we set padding to map.

0. `setPadding()`
`setPadding` shouldn't move map, same behavior  with native-google-map

1. `paddingLatLngFromLatLng()`
Use `project()` instead of `latLngToContainerPoint()`  which can't correctly deal with latlng that out of screen or with certain zoom.
https://leafletjs.com/reference-1.5.0.html#map-project

2. `setZoom()` 
Padding-center should keep the screen point while zooming.

3. `mapMove()`  `getCenter()` 
Padding-center should be return.

4. `getLatLngScreenLocation()`
Point need to convert with window.devicePixelRatio.

## How was it tested?
Build and open sample -> switch to Gaode map -> click animateCenter/center -> 
The blue marker should be at center of screen -> zoom -> addPadding -> click animateCenter/center again -> The blue marker should be at center of map visible area

Before:
![Kapture 2019-10-22 at 11 01 44](https://user-images.githubusercontent.com/31537332/67257390-52b3f600-f4be-11e9-8fd8-9b27c11aa57a.gif)

After:
![Kapture 2019-10-17 at 19 27 49](https://user-images.githubusercontent.com/31537332/67005046-49203c00-f114-11e9-8ae7-fa79ac632382.gif)


@bobby1i 